### PR TITLE
Fix (Perl) meta 'requires' package names for FFI::Platypus & FFI::CheckLib

### DIFF
--- a/perl/Meta
+++ b/perl/Meta
@@ -12,8 +12,8 @@ author:
 
 requires:
   perl: 5.16.0
-  FFI::Platyplus: 2.08
-  FFI::Checklib: 0.31
+  FFI::Platypus: 2.08
+  FFI::CheckLib: 0.31
   JSON: 4.10
 
 test:


### PR DESCRIPTION
Despite appearances on cpantesters, it looks like YAMLScript::FFI is not currently installable from CPAN.

Cheers!