### PR TITLE
perl: Use local libyamlscript build for `make test`

### DIFF
--- a/.version.sh
+++ b/.version.sh
@@ -28,6 +28,7 @@ api_files=(
 perl_files=(
   perl/Meta
   perl/lib/YAMLScript.pm
+  perl/lib/YAMLScript/Alien.pm
   perl-alien/Meta
   perl-alien/lib/Alien/YAMLScript.pm
 )
@@ -52,6 +53,7 @@ yamlscript_files=(
   core/project.clj
   libyamlscript/deps.edn
   libyamlscript/project.clj
+  perl/lib/YAMLScript/Alien.pm
   perl-alien/alienfile
   perl-alien/lib/Alien/YAMLScript.pm
   python/lib/yamlscript/__init__.py

--- a/perl-alien/lib/Alien/YAMLScript.pm
+++ b/perl-alien/lib/Alien/YAMLScript.pm
@@ -1,9 +1,9 @@
+use strict;
+use warnings;
+
 package Alien::YAMLScript;
 
 our $VERSION = '0.1.21';
-
-use strict;
-use warnings;
 
 use parent 'Alien::Base';
 

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -11,10 +11,13 @@ ALIEN_DIST_DIR := $(ROOT)/perl-alien/Alien-YAMLScript-$(PERL_VERSION)
 ALIEN_BLIB_LIB := $(ALIEN_DIST_DIR)/blib/lib
 
 #------------------------------------------------------------------------------
-test:: test-alien
+test::
+	prove -I$< -l $${TEST_VERBOSE:+'-v'} $(test)
 
 test-alien: $(ALIEN_BLIB_LIB)
-	prove -I$< -l $${TEST_VERBOSE:+'-v'} $(test)
+	LD_LIBRARY_PATH= \
+	    DYLD_LIBRARY_PATH= \
+	    prove -I$< -l $${TEST_VERBOSE:+'-v'} $(test)
 
 clean::
 	$(RM) -r cpan YAMLScript-*

--- a/perl/lib/YAMLScript/Alien.pm
+++ b/perl/lib/YAMLScript/Alien.pm
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+package YAMLScript::Alien;
+
+use Alien::YAMLScript;
+
+# Alien::YAMLScript finds the proper libyamlscript version, but we need to be
+# using the proper version of Alien::YAMLScript:
+die "\$YAMLScript::VERSION ($YAMLScript::VERSION) and " .
+    "\$Alien::YAMLScript::VERSION($Alien::YAMLScript::VERSION) " .
+    "must be the same version"
+    unless $YAMLScript::VERSION eq $Alien::YAMLScript::VERSION;


### PR DESCRIPTION
Use `make test-alien` to test Alien::YAMLScript integration.

All the bindings have a `make test` that first builds the shared library and uses the for the test.

Perl eases user installation with Alien::YAMLScript, but that doesn't play well with testing.

Now YAMLScript will look for a local libyamlscript.so.0.1.## and use Alien::YAMLScript if not found.