### PR TITLE
Support error tests

### DIFF
--- a/core/src/yamlscript/transformer.clj
+++ b/core/src/yamlscript/transformer.clj
@@ -57,7 +57,7 @@
           (:Map node))})
 
 (defn transform-sym [node]
-  (let [sym (str node)]
+  (let [sym (str (:Sym node))]
     (when (= sym "%")
       (throw (Exception. "Invalid symbol '%'. Did you mean '%1'?")))
     node))

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -487,3 +487,11 @@
     =>: (a %% b)
   clojure: |
     (mod a b)
+
+
+- name: Error on % in anonymous function
+  yamlscript: |
+    !yamlscript/v0
+    =>: \(inc(%) * 2)
+  error: |-
+    Invalid symbol '%'. Did you mean '%1'?

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -493,5 +493,5 @@
   yamlscript: |
     !yamlscript/v0
     =>: \(inc(%) * 2)
-  error: |-
-    Invalid symbol '%'. Did you mean '%1'?
+  error: |
+    ~~ Invalid symbol '%'. Did you mean '%1'?

--- a/core/test/yamlscript/builder_test.clj
+++ b/core/test/yamlscript/builder_test.clj
@@ -15,15 +15,15 @@
   ["test/compiler-stack.yaml"
    "test/data-mode.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :build] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  composer/compose
-                  resolver/resolve
-                  builder/build))
-   :want-func (fn [test]
-                (->> test
-                  :build
-                  edn/read-string))})
+  {:pick #(test/has-keys? [:yamlscript :build] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             composer/compose
+             resolver/resolve
+             builder/build))
+   :want (fn [test]
+           (->> test
+             :build
+             edn/read-string))})

--- a/core/test/yamlscript/compiler_test.clj
+++ b/core/test/yamlscript/compiler_test.clj
@@ -10,26 +10,24 @@
 (test/load-yaml-test-files
   ["test/compiler.yaml"
    "test/compiler-stack.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :clojure] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  compiler/compile))
-   :want-func (fn [test]
-                (:clojure test))})
+  {:pick #(test/has-keys? [:yamlscript :clojure] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             compiler/compile))
+   :want :clojure})
 
 (test/load-yaml-test-files
   ["test/compiler.yaml"
    "test/compiler-stack.yaml"]
   {:add-tests true
-   :pick-func #(test/has-keys? [:yamlscript :error] %1)
-   :test-func (fn [test]
-                (try
-                  (->> test
-                    :yamlscript
-                    compiler/compile)
-                  ""
-                  (catch Exception e
-                    (:cause (Throwable->map e)))))
-   :want-func (fn [test]
-                (:error test))})
+   :pick #(test/has-keys? [:yamlscript :error] %1)
+   :test (fn [test]
+           (try
+             (->> test
+               :yamlscript
+               compiler/compile)
+             ""
+             (catch Exception e
+               (:cause (Throwable->map e)))))
+   :want :error})

--- a/core/test/yamlscript/compiler_test.clj
+++ b/core/test/yamlscript/compiler_test.clj
@@ -17,3 +17,19 @@
                   compiler/compile))
    :want-func (fn [test]
                 (:clojure test))})
+
+(test/load-yaml-test-files
+  ["test/compiler.yaml"
+   "test/compiler-stack.yaml"]
+  {:add-tests true
+   :pick-func #(test/has-keys? [:yamlscript :error] %1)
+   :test-func (fn [test]
+                (try
+                  (->> test
+                    :yamlscript
+                    compiler/compile)
+                  ""
+                  (catch Exception e
+                    (:cause (Throwable->map e)))))
+   :want-func (fn [test]
+                (:error test))})

--- a/core/test/yamlscript/composer_test.clj
+++ b/core/test/yamlscript/composer_test.clj
@@ -13,13 +13,13 @@
   ["test/compiler-stack.yaml"
    "test/resolver.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :compose] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  composer/compose))
-   :want-func (fn [test]
-                (->> test
-                  :compose
-                  edn/read-string))})
+  {:pick #(test/has-keys? [:yamlscript :compose] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             composer/compose))
+   :want (fn [test]
+           (->> test
+             :compose
+             edn/read-string))})

--- a/core/test/yamlscript/constructor_test.clj
+++ b/core/test/yamlscript/constructor_test.clj
@@ -17,17 +17,17 @@
   ["test/compiler-stack.yaml"
    "test/data-mode.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :construct] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  composer/compose
-                  resolver/resolve
-                  builder/build
-                  transformer/transform
-                  constructor/construct))
-   :want-func (fn [test]
-                (->> test
-                  :construct
-                  edn/read-string))})
+  {:pick #(test/has-keys? [:yamlscript :construct] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             composer/compose
+             resolver/resolve
+             builder/build
+             transformer/transform
+             constructor/construct))
+   :want (fn [test]
+           (->> test
+             :construct
+             edn/read-string))})

--- a/core/test/yamlscript/parser_test.clj
+++ b/core/test/yamlscript/parser_test.clj
@@ -12,14 +12,14 @@
   ["test/compiler-stack.yaml"
    "test/resolver.yaml"
    "test/data-mode.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :parse] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  (map pr-str)
-                  (map #(subs %1 4 (dec (count %1))))))
-   :want-func (fn [test]
-                (->> test
-                  :parse
-                  str/split-lines))})
+  {:pick #(test/has-keys? [:yamlscript :parse] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             (map pr-str)
+             (map #(subs %1 4 (dec (count %1))))))
+   :want (fn [test]
+           (->> test
+             :parse
+             str/split-lines))})

--- a/core/test/yamlscript/printer_test.clj
+++ b/core/test/yamlscript/printer_test.clj
@@ -17,17 +17,15 @@
   ["test/compiler-stack.yaml"
    "test/data-mode.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :print] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  composer/compose
-                  resolver/resolve
-                  builder/build
-                  transformer/transform
-                  constructor/construct
-                  printer/print))
-   :want-func (fn [test]
-                (->> test
-                  :print))})
+  {:pick #(test/has-keys? [:yamlscript :print] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             composer/compose
+             resolver/resolve
+             builder/build
+             transformer/transform
+             constructor/construct
+             printer/print))
+   :want :print})

--- a/core/test/yamlscript/resolver_test.clj
+++ b/core/test/yamlscript/resolver_test.clj
@@ -15,19 +15,19 @@
    "test/data-mode.yaml"
    "test/resolver.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :resolve] %1)
-   :test-func (fn [test]
-                (try
-                  (->> test
-                    :yamlscript
-                    parser/parse
-                    composer/compose
-                    resolver/resolve)
-                  (catch Exception e
-                    (if (:error test)
-                      (.getMessage e)
-                      (throw e)))))
-   :want-func (fn [test]
-                (->> test
-                  :resolve
-                  edn/read-string))})
+  {:pick #(test/has-keys? [:yamlscript :resolve] %1)
+   :test (fn [test]
+           (try
+             (->> test
+               :yamlscript
+               parser/parse
+               composer/compose
+               resolver/resolve)
+             (catch Exception e
+               (if (:error test)
+                 (.getMessage e)
+                 (throw e)))))
+   :want (fn [test]
+           (->> test
+             :resolve
+             edn/read-string))})

--- a/core/test/yamlscript/transformer_test.clj
+++ b/core/test/yamlscript/transformer_test.clj
@@ -15,16 +15,16 @@
 (test/load-yaml-test-files
   ["test/compiler-stack.yaml"
    "test/compiler.yaml"]
-  {:pick-func #(test/has-keys? [:yamlscript :transform] %1)
-   :test-func (fn [test]
-                (->> test
-                  :yamlscript
-                  parser/parse
-                  composer/compose
-                  resolver/resolve
-                  builder/build
-                  transformer/transform))
-   :want-func (fn [test]
-                (->> test
-                  :transform
-                  edn/read-string))})
+  {:pick #(test/has-keys? [:yamlscript :transform] %1)
+   :test (fn [test]
+           (->> test
+             :yamlscript
+             parser/parse
+             composer/compose
+             resolver/resolve
+             builder/build
+             transformer/transform))
+   :want (fn [test]
+           (->> test
+             :transform
+             edn/read-string))})

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -12,7 +12,7 @@ ALIEN_BLIB_LIB := $(ALIEN_DIST_DIR)/blib/lib
 
 #------------------------------------------------------------------------------
 test::
-	prove -I$< -l $${TEST_VERBOSE:+'-v'} $(test)
+	prove -l $${TEST_VERBOSE:+'-v'} $(test)
 
 test-alien: $(ALIEN_BLIB_LIB)
 	LD_LIBRARY_PATH= \

--- a/yamltest/src/yamltest/core.clj
+++ b/yamltest/src/yamltest/core.clj
@@ -133,7 +133,7 @@
            (str "No tests found to run. (" ~ns ")"))))))
 
 ;; ----------------------------------------------------------------------------
-(defn read-tests [file pick-func]
+(defn read-tests [file pick]
   (let [tests (->> file
                 slurp
                 yaml/parse-string
@@ -144,7 +144,7 @@
                 (filter :ONLY tests)
                 tests)
         tests (->> tests
-                (filter pick-func))]
+                (filter pick))]
     tests))
 
 (defn add-test-to-ns [ns sym testfn]
@@ -173,10 +173,11 @@
     (fn [file]
       (let [conf (assoc conf :yaml-file file)
             {:keys [yaml-file
-                    pick-func
-                    test-func
-                    want-func]} conf
-            tests (read-tests yaml-file pick-func)
+                    pick
+                    test
+                    want]} conf
+            test-fn test
+            tests (read-tests yaml-file pick)
             only (vec (filter :ONLY tests))
             tests (if (seq only)
                     (do (do-remove-tests ns) only)
@@ -193,8 +194,8 @@
               (fn []
                 (when (:verbose @test-opts)
                   (println (str "* " test-name " - " (:name test))))
-                (let [got (test-func test)
-                      want (want-func test)]
+                (let [got (test-fn test)
+                      want (want test)]
                   (cond
                     (and (string? want) (re-find #"^=~\s*" want))
                     (let [want (str/replace want #"^=~\s*" "")


### PR DESCRIPTION
This PR supports prefixing expected output with `=~` for regex match or `~~` for contains substring.

The point is to make it easier to write error tests.

Also did some refactoring to simplify testing.