### PR TITLE
Allow for description string in defn

### DIFF
--- a/core/src/yamlscript/macros.clj
+++ b/core/src/yamlscript/macros.clj
@@ -1,0 +1,33 @@
+;; Copyright 2023-2024 Ingy dot Net
+;; This code is licensed under MIT license (See License for details)
+
+;; A collection of YAMLScript macros that are used to transform certain mappings
+;; into other mappings.
+
+(ns yamlscript.macros
+  (:require
+   [clojure.string :as str]
+   [yamlscript.debug :refer [www]]))
+
+(defn defn-docstring [node]
+  (if-let
+   [new-node
+    (when-let [ysm (get-in node [:ysm])]
+      (when-let [[key val] (and (= 2 (count ysm)) ysm)]
+        (when (and
+                (= 'defn (get-in key [0 :Sym]))
+                (get-in key [1 :Sym])
+                (get-in key [2 :Vec]))
+          (when-let [doc-string (and
+                                  (= '=> (get-in val [:ysm 0 :Sym]))
+                                  (get-in val [:ysm 1 :Str]))]
+            (let [[a b c] key
+                  node (update-in node [:ysm 1 :ysm] #(drop 2 %1))
+                  node (update-in node [:ysm 0]
+                         (fn [_] [a b {:Str doc-string} c]))]
+              node)))))]
+    new-node
+    node))
+
+(comment
+  www)

--- a/core/src/yamlscript/transformer.clj
+++ b/core/src/yamlscript/transformer.clj
@@ -6,6 +6,7 @@
 
 (ns yamlscript.transformer
   (:require
+   [yamlscript.macros :as ymac]
    [yamlscript.debug :refer [www]]))
 
 (declare transform-node)
@@ -40,7 +41,8 @@
       #(if (vector? %1)
          (map-vec transform-node %1)
          (transform-node %1)))
-    (hash-map :ysm)))
+    (hash-map :ysm)
+    ymac/defn-docstring))
 
 (defn transform-list [node]
   (or

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -495,3 +495,17 @@
     =>: \(inc(%) * 2)
   error: |
     ~~ Invalid symbol '%'. Did you mean '%1'?
+
+
+- name: Support doc string in defn
+  yamlscript: |
+    !yamlscript/v0
+    defn foo():
+      =>: "This is a doc string"
+      say: "Hello World"
+  transform: |
+    {:ysm
+     [[{:Sym defn} {:Sym foo} {:Str "This is a doc string"} {:Vec []}]
+      {:ysm ({:Sym say} {:Str "Hello World"})}]}
+  clojure: |
+    (defn foo "This is a doc string" [] (say "Hello World"))


### PR DESCRIPTION
Can happen in the transformer.

Might be a good first use case for `ys-macro` (defsyn).