### PR TITLE
Error on parsing token that is valid Clojure symbol but not valid YS symbol

### DIFF
--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -64,6 +64,7 @@
 (def pkey (re #"(?:$symw|$pnum|$strg)"))   ; Path key
 (def path (re #"(?:$symw(?:\.$pkey)+)"))   ; Lookup path
 (def keyw (re #"(?:\:$symw)"))             ; Keyword token
+(def csym #"(?:[-a-zA-Z0-9_'*+?!<=>]+)")   ; Clojure symbol
 (def symb (re #"(?:_[*+.]|$symw[?!]?)"))   ; Symbol token
 (def nspc (re #"(?:$symw(?:\:\:$symw)+)")) ; Namespace symbol
 (def fqsm (re #"(?:$nspc\.$symb)"))        ; Fully qualified symbol

--- a/core/src/yamlscript/ysreader.clj
+++ b/core/src/yamlscript/ysreader.clj
@@ -47,6 +47,9 @@
 (defn is-unquote-splice? [token]
   (and token (= "~@" (str token))))
 
+(defn is-clojure-symbol? [token]
+  (and token (re-matches re/csym (str token))))
+
 (defn is-string? [token]
   (and token (re-matches re/strg (str token))))
 
@@ -77,7 +80,7 @@
       $nspc |                   # Namespace symbol
       $path |                   # Lookup path
       $lnum |                   # Number token
-      $symb |                   # Symbol token
+      $csym |                   # Clojure symbol
       $narg |                   # Numbered argument token
       $oper |                   # Operator token
       $char |                   # Character token
@@ -236,6 +239,9 @@
       [(Sym sym) tokens])
     ,
     (is-symbol? token) [(Sym token) tokens]
+    (is-clojure-symbol? token)
+    (throw (Exception. (str "Invalid symbol: '" token "'")))
+    ,
     (is-namespace? token) [(Spc token) tokens]
     :else (throw (Exception. (str "Unexpected token: '" token "'")))))
 

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -519,3 +519,11 @@
       say: "Hello World"
   clojure: |
     (defn foo "This is a doc string" [] (say "Hello World"))
+
+
+- name: Error on `a+b`
+  yamlscript: |
+    !yamlscript/v0
+    =>: a+b
+  error: |-
+    Invalid symbol: 'a+b'


### PR DESCRIPTION
Legal YS symbols are a small subset of what is allowed in Clojure.
We only allow symbols that are commonly seen in Clojure.
This includes all the public symbols from `clojure.core`.
Fortunately this is a very small sane group.

From the Clojure reference:

> Symbols begin with a non-numeric character and can contain alphanumeric characters and *, +, !, -, _, ', ?, <, > and = (other characters may be allowed eventually).

YS Symbols:

* Start with an alpha
* Consist on 1 or more ascii alphanumeric words separated by a `-`
* May have a suffix of `?` `!` `->` or `->>`

We want to start off as strict as plausible. I've never seen Clojure symbols in the wild outside this pattern except for `a->b` names that could be expressed `a-to-b` or `a2b` with equal clarity.

We can relax the rules later as needed but being strict now allows us to consider forms that may make a lot of sense to YS.

Note that even `_` is disallowed.
The good side of this is that we can use `_` internally for simple,  more readable symbol mangling.
For instance the math `+` operator often gets converted to the polymorphic `_+` function that can add numbers and concatenate strings.
We know it won't conflict with a user's `_+` symbol because it is not valid in YS.

----

The point of this issue is to throw an error when we encounter a valid Clojure symbol that is an invalid YS symbol.
This will prevent a lot of mistakes.

Currently `a+b` is parsed same as `a + b`.
After fixing this issue `a+b` will be an error, as will `a +b` and `a+ b`.
Users will need to use the `a + b` ws separated form to add `a` and `b`.