### PR TITLE
Perl: look into performance issues

### DIFF
--- a/core/src/yamlscript/compiler.clj
+++ b/core/src/yamlscript/compiler.clj
@@ -72,6 +72,16 @@
     yamlscript.printer/print
     (debug-print "print")))
 
+(defn pretty-format [code]
+  (->> code
+    (#(str "(do " %1 "\n)\n"))
+    read-string
+    rest
+    (map #(str
+            (with-out-str (clojure.pprint/write %1))
+            "\n"))
+    (apply str)))
+
 (comment
   www
 ; {:do [[{:Sym a} {:Sym b}]]}

--- a/core/src/yamlscript/printer.clj
+++ b/core/src/yamlscript/printer.clj
@@ -7,7 +7,6 @@
 (ns yamlscript.printer
   (:require
    [clojure.string :as str]
-   [clojure.pprint :as pp]
    [yamlscript.debug :refer [www]])
   (:refer-clojure :exclude [print]))
 
@@ -58,25 +57,13 @@
               (Exception. (str "Unknown AST node type:"
                             node))))))
 
-(defn pretty-format [code]
-  (->> code
-    (#(str "(do " %1 "\n)\n"))
-    read-string
-    rest
-    (map #(str
-            (with-out-str (pp/write %1))
-            "\n"))
-    (str/join "")))
-
-
 (defn print
   "Render a YAMLScript AST as Clojure code."
   [node]
   (let [list (:Top node)
         code (->> list
                (map print-node)
-               (str/join "\n")
-               pretty-format)]
+               (apply str))]
     code))
 
 (comment

--- a/core/test/yamlscript/compiler_test.clj
+++ b/core/test/yamlscript/compiler_test.clj
@@ -14,7 +14,8 @@
    :test (fn [test]
            (->> test
              :yamlscript
-             compiler/compile))
+             compiler/compile
+             compiler/pretty-format))
    :want :clojure})
 
 (test/load-yaml-test-files

--- a/core/test/yamlscript/printer_test.clj
+++ b/core/test/yamlscript/printer_test.clj
@@ -4,6 +4,7 @@
 (ns yamlscript.printer-test
   #_(:use yamlscript.debug)
   (:require
+   [yamlscript.compiler :as compiler]
    [yamlscript.parser :as parser]
    [yamlscript.composer :as composer]
    [yamlscript.resolver :as resolver]
@@ -27,5 +28,6 @@
              builder/build
              transformer/transform
              constructor/construct
-             printer/print))
+             printer/print
+             compiler/pretty-format))
    :want :print})

--- a/perl-alien/Meta
+++ b/perl-alien/Meta
@@ -12,7 +12,7 @@ author:
 
 requires:
   perl: 5.16.0
-  JSON: 4.10
+  Cpanel::JSON::XS: 4.37
 
 test:
   requires:

--- a/perl-alien/test/ffi.t
+++ b/perl-alien/test/ffi.t
@@ -2,7 +2,7 @@
 
 use Test2::V0 -target => 'Alien::YAMLScript';
 use Test::Alien;
-use JSON::PP;
+use Cpanel::JSON::XS;
 
 alien_ok $CLASS;
 

--- a/perl/Meta
+++ b/perl/Meta
@@ -15,7 +15,7 @@ requires:
   Alien::YAMLScript: 0.1.22
   FFI::CheckLib: 0.31
   FFI::Platypus: 2.08
-  JSON: 4.10
+  Cpanel::JSON::XS: 4.37
 
 test:
   requires:

--- a/perl/lib/YAMLScript.pm
+++ b/perl/lib/YAMLScript.pm
@@ -5,7 +5,7 @@ package YAMLScript;
 
 use FFI::CheckLib ();
 use FFI::Platypus;
-use JSON ();
+use Cpanel::JSON::XS ();
 
 our $VERSION = '0.1.22';
 
@@ -71,7 +71,7 @@ $ffi->attach(
         my ($xsub, $self, $ys) = @_;
         $self->{error} = undef;
 
-        my $resp = JSON::decode_json(
+        my $resp = Cpanel::JSON::XS::decode_json(
             $xsub->(${$self->{isolatethread}}, $ys)
         );
 

--- a/ys/src/yamlscript/cli.clj
+++ b/ys/src/yamlscript/cli.clj
@@ -299,12 +299,12 @@ Options:
                       "")))]
         (die msg)))))
 
-
 (defn do-compile [opts args]
   (let [[code _ _ #_file #_args] (get-code opts args)]
     (-> code
       (compile-code opts)
       str/trim-newline
+      compiler/pretty-format
       println)))
 
 (defn do-repl [opts]


### PR DESCRIPTION
YAMLScript.pm performs poorly in benchmarks.

My assumption is that libyamlscript is fast but then deserializing the returned JSON to Perl data is slow.

Try using JSON::XS instead of JSON.

Also see if isolate reuse is good or bad.
Look into GC triggering.