### PR TITLE
Implement `%:` and `=>:` pair separators for ysg semantics

### DIFF
--- a/core/src/yamlscript/constructor.clj
+++ b/core/src/yamlscript/constructor.clj
@@ -52,11 +52,22 @@
                        [[lhs rhs] & pairs] pairs
                        lhs (construct-side lhs ctx)
                        rhs (construct-side rhs ctx)
-                       pair [lhs rhs]
-                       new (conj new (construct-call pair))]
+                       rhs (or (:ysg rhs) rhs)
+                       new (conj new (construct-call [lhs rhs]))]
                    (recur pairs, new))
                  new))]
     node))
+
+(defn construct-ysg [node ctx]
+  (let [nodes (:ysg node)
+        nodes (reduce
+                (fn [nodes node]
+                  (let [node (construct-node node ctx)]
+                    (if (not= '=> (:Sym node))
+                      (conj nodes node)
+                      nodes)))
+                [] nodes)]
+    {:ysg nodes}))
 
 (defn construct-node [node ctx]
   (when (vector? ctx) (throw (Exception. "ctx is a vector")))
@@ -64,6 +75,7 @@
         ctx (update-in ctx [:lvl] inc)]
     (case key
       :ysm (construct-ysm node ctx)
+      :ysg (construct-ysg node ctx)
       ,    node)))
 
 ;;------------------------------------------------------------------------------

--- a/core/src/yamlscript/transformer.clj
+++ b/core/src/yamlscript/transformer.clj
@@ -33,7 +33,7 @@
           [_ v2 v3] list]
       {:Lst [{:Sym '_*} v2 v3]})))
 
-(defn transform-ysm [node]
+(defn transform-ysm [node key]
   (->> node
     first
     val
@@ -41,8 +41,8 @@
       #(if (vector? %1)
          (map-vec transform-node %1)
          (transform-node %1)))
-    (hash-map :ysm)
-    (yamlscript.macros/apply-macros :ysm)))
+    (hash-map key)
+    (yamlscript.macros/apply-macros key)))
 
 (defn transform-list [node]
   (or
@@ -70,7 +70,8 @@
 (defn transform-node [node]
   (let [[key] (first node)]
     (case key
-      :ysm (transform-ysm node)
+      :ysm (transform-ysm node :ysm)
+      :ysg (transform-ysm node :ysg)
       :Lst (transform-list node)
       :Map (transform-map node)
       :Sym (transform-sym node)

--- a/core/test/compiler-stack.yaml
+++ b/core/test/compiler-stack.yaml
@@ -26,7 +26,6 @@
     # 'TEMPLATE: true' is here to ignore this test block
 
 
-
 - name: Most YAML syntax forms in one example
   yamlscript: |
     --- !yamlscript/v0
@@ -83,7 +82,6 @@
           ]} ]} ]} ]}
 
 
-
 - name: Nested parse events test
   yamlscript: |
     a:
@@ -106,7 +104,6 @@
     "=VAL", := "g"
     "=VAL", := "h"
     "-MAP"
-
 
 
 - name: Basic function call with 2 args (test all phases)
@@ -140,7 +137,6 @@
     (a b c)
 
 
-
 - name: Dot escaping
   yamlscript: |
     --- !yamlscript/v0
@@ -156,7 +152,6 @@
       {:= ".[2 4 6 8]"} ]}
   print: |
     (map inc [2 4 6 8])
-
 
 
 - name: YS reader forms
@@ -192,7 +187,6 @@
     (prn "A longer string")
 
 
-
 - name: Basic math ysexpr
   yamlscript: |
     --- !yamlscript/v0
@@ -203,7 +197,6 @@
       {:Lst [{:Sym *} {:Int 6} {:Int 7}]}]}
   print: |
     (inc (_* 6 7))
-
 
 
 - name: Function call ysexpr
@@ -221,7 +214,6 @@
     (say (str "The number is: " (inc 41)))
 
 
-
 - name: def expression
   yamlscript: |
     !yamlscript/v0
@@ -234,7 +226,6 @@
      {:Int 123}]}
   print: |
     (def foo 123)
-
 
 
 - name: defn expression
@@ -251,7 +242,6 @@
     (defn foo [a b] (_+ a b))
 
 
-
 - name: Structured defn expression
   yamlscript: |
     !yamlscript/v0
@@ -265,7 +255,6 @@
         [{:Sym a} {:Sym b}]]}]}
   print: |
     (defn foo [a b] (add a b))
-
 
 
 - name: def/let expression
@@ -335,7 +324,6 @@
     bar: 10 20
 
 
-
 - name: The 'if' special form
   yamlscript: |
     !yamlscript/v0
@@ -344,7 +332,6 @@
       bar(a b)
   print: |
     (if (> a b) (foo a b) (bar a b))
-
 
 
 - name: Top level scalar in data mode
@@ -356,7 +343,6 @@
     {:str "(foo bar)"}
   print: |
     "(foo bar)"
-
 
 
 - name: Top level scalar in code mode
@@ -371,7 +357,6 @@
     (foo bar)
 
 
-
 - name: Top level comment eats following lines
   yamlscript: |
     !yamlscript/v0
@@ -382,8 +367,6 @@
   parse: |
     "=VAL", :! "yamlscript/v0", := "; comment (foo bar)"
   print: |
-
-
 
 
 - name: Switch to code mode
@@ -421,7 +404,6 @@
     {"str" "foo bar", "num" (inc 41), "bar" (load "bar.yaml")}
 
 
-
 - name: Shebang line with ys-0 implies !yamlscript/v0
   yamlscript: |
     #!/usr/bin/env ys-0
@@ -434,7 +416,6 @@
     "-MAP"
 
 
-
 - name: Shebang line with ys-0 and !yamlscript/... tag ignored
   yamlscript: |
     #!/usr/bin/env ys-0
@@ -445,7 +426,6 @@
     "=VAL", := "say"
     "=VAL", :$ "Hi"
     "-MAP"
-
 
 
 - name: Double quoted string with escaped newline

--- a/core/test/compiler-stack.yaml
+++ b/core/test/compiler-stack.yaml
@@ -478,3 +478,33 @@
      [{:ysx "def add"} {:ysm [{:ysx "fn [a b]"} {:ysx "a + b"}]}]}
   clojure: |
     (def add (fn [a b] (_+ a b)))
+
+
+- name: Support '%:' for left/right grouping
+  yamlscript: |
+    !yamlscript/v0
+    foo %:
+      (a > b): c
+      (a < d): e
+      =>: f
+  resolve: |
+    {:ysm
+     [{:ysx "foo"}
+      {:ysg
+       [{:ysx "(a > b)"}
+        {:ysx "c"}
+        {:ysx "(a < d)"}
+        {:ysx "e"}
+        {:ysx "=>"}
+        {:ysx "f"}]}]}
+  construct: |
+    {:Top
+     [{:Lst
+       [{:Sym foo}
+        {:Lst [{:Sym >} {:Sym a} {:Sym b}]}
+        {:Sym c}
+        {:Lst [{:Sym <} {:Sym a} {:Sym d}]}
+        {:Sym e}
+        {:Sym f}]}]}
+  print: |
+    (foo (> a b) c (< a d) e f)

--- a/sample/rosetta-code/100-doors.ys
+++ b/sample/rosetta-code/100-doors.ys
@@ -6,7 +6,8 @@ defn main():
     $(apply str interpose(\", \" open-doors()))"
 
 defn open-doors():
-  for: .[[d n] map(vector doors() iterate(inc 1)) :when d] n
+  for [[d n] map(vector doors() iterate(inc 1)) :when d]:
+    n
 
 defn doors():
   reduce:

--- a/sample/rosetta-code/99-bottles-of-beer.ys
+++ b/sample/rosetta-code/99-bottles-of-beer.ys
@@ -6,9 +6,9 @@
 #   ys 99-bottles.ys [<count>]
 
 defn main(&[number]):
-  each [n ((number || 99) .. 1)]:
-    say:
-      paragraph: n
+  number =: number || 99
+  each [n (number .. 1)]:
+    say: paragraph(n)
 
 defn paragraph(num): |
   $(bottles num) of beer on the wall,
@@ -17,7 +17,7 @@ defn paragraph(num): |
   $(bottles (num - 1)) of beer on the wall.
 
 defn bottles(n):
-  cond:
-    (n == 0) "No more bottles"
-    (n == 1) "1 bottle"
-    :else    str(n " bottles")
+  cond %:
+    (n == 0): "No more bottles"
+    (n == 1): "1 bottle"
+    :else   : "$n bottles"

--- a/sample/rosetta-code/fizzbuzz.ys
+++ b/sample/rosetta-code/fizzbuzz.ys
@@ -9,8 +9,7 @@
 
 defn main(&[count impl]):
   count =: count || 100
-  impl =:
-    str: impl || "1"
+  impl =: impl || "1"
   fizzbuzz =: "fizzbuzz-$impl"
 
   when-not ENV."YS_TEST":
@@ -28,11 +27,11 @@ defn main(&[count impl]):
 defn fizzbuzz-1(n):
   map:
     fn(x):
-      cond:
-        zero?(mod(x 15)) "FizzBuzz"
-        zero?(mod(x 5))  "Buzz"
-        zero?(mod(x 3))  "Fizz"
-        :else            x
+      cond %:
+        zero?(mod(x 15)): "FizzBuzz"
+        zero?(mod(x 5)):  "Buzz"
+        zero?(mod(x 3)):  "Fizz"
+        :else:            x
     =>: (1 .. n)
 
 defn fizzbuzz-2(n):
@@ -42,11 +41,11 @@ defn fizzbuzz-2(n):
       recur:
         inc: i
         conj l:
-          cond:
-            zero?(mod(i 15)) "FizzBuzz"
-            zero?(mod(i 5))  "Buzz"
-            zero?(mod(i 3))  "Fizz"
-            :else            i
+          cond %:
+            zero?(mod(i 15)): "FizzBuzz"
+            zero?(mod(i 5)):  "Buzz"
+            zero?(mod(i 3)):  "Fizz"
+            :else:            i
 
 defn fizzbuzz-3(n):
   map:
@@ -56,4 +55,4 @@ defn fizzbuzz-3(n):
           when zero?(mod(x 3)): "Fizz"
           when zero?(mod(x 5)): "Buzz"
       if empty?(s): x s
-    rng: 1, n
+    =>: 1..n


### PR DESCRIPTION
this
```
cond:
  (x > 3): foo(x)
  (x < 10): bar(x)
  :else: baz(x)
```
should compile to:
```
(cond
  (> x 3) (foo x)
  (< x 10) (bar x)
  :else (baz x))
```
but it compiles to
```
(cond
  (> x 3 (foo x))
  (< x 10 (bar x))
  (:else (baz x)))
```
you can get the right semantics with either
```
cond %:
  (x > 3): foo(x)
  (x < 10): bar(x)
  :else: baz(x)
```
or:
```
cond:
  (x > 3) =>: foo(x)
  (x < 10) =>: bar(x)
  :else =>: baz(x)
```
