### PR TITLE
Add ys-macros for `cond` and `case`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "cSpell.words": [
     "concat",
     "cond",
+    "condp",
     "debuginfo",
     "defmacro",
     "defn",

--- a/core/src/yamlscript/resolver.clj
+++ b/core/src/yamlscript/resolver.clj
@@ -31,7 +31,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [yamlscript.re :as re]
-   [yamlscript.util :refer [when-let*]]
+   [yamlscript.util :refer [when-lets]]
    [yamlscript.debug :refer [www]])
   (:refer-clojure :exclude [resolve]))
 
@@ -71,13 +71,13 @@
 ;; Resolve taggers for code mode:
 ;; ----------------------------------------------------------------------------
 (defn tag-str [[key val]]
-  (when-let*
+  (when-lets
     [str (:ysi key)
      _ (= "" (:ysx val))]
     [{:str str} {:str ""}]))
 
 (defn tag-def [[key val]]
-  (when-let*
+  (when-lets
     [key (:ysx key)
      old key
      rgx (re/re #"^($symw) +=$")

--- a/core/src/yamlscript/util.clj
+++ b/core/src/yamlscript/util.clj
@@ -9,21 +9,11 @@
    [yamlscript.debug :refer [www]]))
 
 
-(defmacro if-let*
-  ([bindings then]
-   `(if-let* ~bindings ~then nil))
-  ([bindings then else]
-   (if (seq bindings)
-     `(if-let [~(first bindings) ~(second bindings)]
-        (if-let* ~(drop 2 bindings) ~then ~else)
-        ~else)
-     then)))
-
-(defmacro when-let*
+(defmacro when-lets
   ([bindings & body]
    (if (seq bindings)
      `(when-let [~(first bindings) ~(second bindings)]
-        (when-let* ~(drop 2 bindings) ~@body))
+        (when-lets ~(drop 2 bindings) ~@body))
      `(do ~@body))))
 
 (comment

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -569,12 +569,12 @@
     (when (=-- a b) (c))
 
 
-- name: Macros for cond and case
+- name: Macros for case, cond, condp
   yamlscript: |
     !yamlscript/v0
     cond:
       (a > b): c
       (a < d): e
-      true: f
+      =>: f
   clojure: |
     (cond (> a b) c (< a d) e true f)

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -567,3 +567,14 @@
     when (a =~ b): c()
   clojure: |
     (when (=-- a b) (c))
+
+
+- name: Macros for cond and case
+  yamlscript: |
+    !yamlscript/v0
+    cond:
+      (a > b): c
+      (a < d): e
+      true: f
+  clojure: |
+    (cond (> a b) c (< a d) e true f)

--- a/sample/rosetta-code/99-bottles-of-beer.ys
+++ b/sample/rosetta-code/99-bottles-of-beer.ys
@@ -17,7 +17,7 @@ defn paragraph(num): |
   $(bottles (num - 1)) of beer on the wall.
 
 defn bottles(n):
-  cond %:
+  cond:
     (n == 0): "No more bottles"
     (n == 1): "1 bottle"
     :else   : "$n bottles"

--- a/sample/rosetta-code/99-bottles-of-beer.ys
+++ b/sample/rosetta-code/99-bottles-of-beer.ys
@@ -18,6 +18,6 @@ defn paragraph(num): |
 
 defn bottles(n):
   cond:
-    (n == 0): "No more bottles"
-    (n == 1): "1 bottle"
-    :else   : "$n bottles"
+    (n == 0) : "No more bottles"
+    (n == 1) : "1 bottle"
+    =>       : "$n bottles"

--- a/sample/rosetta-code/fizzbuzz.ys
+++ b/sample/rosetta-code/fizzbuzz.ys
@@ -27,7 +27,7 @@ defn main(&[count impl]):
 defn fizzbuzz-1(n):
   map:
     fn(x):
-      cond %:
+      cond:
         zero?(mod(x 15)): "FizzBuzz"
         zero?(mod(x 5)):  "Buzz"
         zero?(mod(x 3)):  "Fizz"
@@ -41,7 +41,7 @@ defn fizzbuzz-2(n):
       recur:
         inc: i
         conj l:
-          cond %:
+          cond:
             zero?(mod(i 15)): "FizzBuzz"
             zero?(mod(i 5)):  "Buzz"
             zero?(mod(i 3)):  "Fizz"

--- a/sample/rosetta-code/fizzbuzz.ys
+++ b/sample/rosetta-code/fizzbuzz.ys
@@ -31,8 +31,8 @@ defn fizzbuzz-1(n):
         zero?(mod(x 15)): "FizzBuzz"
         zero?(mod(x 5)):  "Buzz"
         zero?(mod(x 3)):  "Fizz"
-        :else:            x
-    =>: (1 .. n)
+        =>: x
+    =>: 1 .. n
 
 defn fizzbuzz-2(n):
   loop [i 1, l []]:
@@ -45,7 +45,7 @@ defn fizzbuzz-2(n):
             zero?(mod(i 15)): "FizzBuzz"
             zero?(mod(i 5)):  "Buzz"
             zero?(mod(i 3)):  "Fizz"
-            :else:            i
+            =>: i
 
 defn fizzbuzz-3(n):
   map:
@@ -55,4 +55,4 @@ defn fizzbuzz-3(n):
           when zero?(mod(x 3)): "Fizz"
           when zero?(mod(x 5)): "Buzz"
       if empty?(s): x s
-    =>: 1..n
+    rng: 1 n


### PR DESCRIPTION
cond and case have `%:` semantics where the key/val forms of pairs stay separate.

```
cond:
  (x > 3): foo(x)
  (x < 10): bar(x)
  =>: baz(x)
```
->
```
(cond
  (> x 3) (foo x)
  (< x 10) (bar x)
  :else (baz x))
```