### PR TITLE
Support single quoted strings in ys expressions

### DIFF
--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -60,21 +60,26 @@
               [^\\\/\n]                      # Any other char
             )+/                              # Ending slash
             ")
-(def strg #"(?x)
-            \#?                            # Possibly a regex
-            \"(?:                          # Quoted string
+(def dstr #"(?x)
+            \"(?:                          # Double quoted string
               \\. |                          # Escaped char
               [^\\\"]                        # Any other char
             )*\"                             # Ending quote
             ")
+(def sstr #"(?x)
+            '(?:                          # Sinlge quoted string
+              '' |                           # Escaped single quote
+              [^']                           # Any other char
+            )*'                              # Ending quote
+            ")
 (def pnum #"(?:\d+)")                      ; Positive integer
 (def anum #"[a-zA-Z0-9]")                  ; Alphanumeric
 (def symw #"(?:$anum+(?:-$anum+)*)")       ; Symbol word
-(def pkey (re #"(?:$symw|$pnum|$strg)"))   ; Path key
+(def pkey (re #"(?:$symw|$pnum|$dstr|$sstr)"))   ; Path key
 (def path (re #"(?:$symw(?:\.$pkey)+)"))   ; Lookup path
 (def keyw (re #"(?:\:$symw)"))             ; Keyword token
                                            ; Clojure symbol
-(def csym #"(?:[-a-zA-Z0-9_'*+?!<=>]+(?:\.(?=\ ))?)")
+(def csym #"(?:[-a-zA-Z0-9_*+?!<=>]+(?:\.(?=\ ))?)")
 (def symb (re #"(?:$symw[?!.]?)"))         ; Symbol token
 (def nspc (re #"(?:$symw(?:\:\:$symw)+)")) ; Namespace symbol
 (def fqsm (re #"(?:$nspc\.$symb)"))        ; Fully qualified symbol

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -578,3 +578,11 @@
       =>: f
   clojure: |
     (cond (> a b) c (< a d) e true f)
+
+
+- name: Single quoted string
+  yamlscript: |
+    !yamlscript/v0
+    say: 123 + 'let''s go'
+  clojure: |
+    (say (_+ 123 "let's go"))

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -583,6 +583,8 @@
 - name: Single quoted string
   yamlscript: |
     !yamlscript/v0
-    say: 123 + 'let''s go'
+    say: ."123" + ' let''s go'
+    say: '123 let''s go'
   clojure: |
-    (say (_+ 123 "let's go"))
+    (say (_+ "123" " let's go"))
+    (say "123 let's go")


### PR DESCRIPTION
In YAML `'` is for quoting strings. In clojure it applies the `quote` function to an expression.

In YS it should always be used to quote a string, and without interpolation semantics.

Since it is just a sugar syntax in Clojure `'foo` -> `(quote foo)` we will just require the long form for now.

We'll adjust as necessary to not make this annoying. There are lots of options at out disposal.