### PR TITLE
Change fully qualified symbol syntax

### DIFF
--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -82,7 +82,7 @@
 (def ysym (re #"(?:$symw[?!.]?)"))         ; YS symbol token
 (def dsym (re #"(?:$symw=)"))              ; YS symbol with default
 (def nspc (re #"(?:$symw(?:\:\:$symw)+)")) ; Namespace symbol
-(def fsym (re #"(?:$nspc\.$ysym)"))        ; Fully qualified symbol
+(def fsym (re #"(?:(?:$nspc|$symw)\/$ysym)"))  ; Fully qualified symbol
                                            ; Symbol followed by paren
 (def psym (re #"(?:(?:$fsym|$ysym)\()"))
 (def esym (re #"(?:\*$symw\*)"))           ; Earmuff symbol

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -320,9 +320,11 @@
 - name: Fully qualified symbols
   yamlscript: |
     !yamlscript/v0
-    ys::std.say: ys
+    ys::std/say: ys
+    foo/bar: baz
   clojure: |
     (ys.std/say ys)
+    (foo/bar baz)
 
 
 - name: Anonymous function

--- a/ys/test/yamlscript/cli_test.clj
+++ b/ys/test/yamlscript/cli_test.clj
@@ -61,13 +61,13 @@
     #"ys\.std.say"
     "'say' evaluates to a symbol")
 
-  (is (ys "-ce" "ys::std.say: 123")
+  (is (ys "-ce" "ys::std/say: 123")
     "(ys.std/say 123)"
     "-c prints Clojure code of compilation")
 
-  (is (ys "-e" "ys::std.say: 123")
+  (is (ys "-e" "ys::std/say: 123")
     "123"
-    "ys::std.say is the YS std println")
+    "ys::std/say is the YS std println")
 
   (is (ys "-mc" "-le" "say: 12345" "-e" "=>: 67890")
     "12345\n67890"


### PR DESCRIPTION
Currently `foo::bar.baz`.
Change to `foo::bar:baz` or `foo::bar/baz`.
Without the change, `foo.baz` is problematic.