### PR TITLE
Most common java.lang.* classes missing in runtime

### DIFF
--- a/core/src/yamlscript/runtime.clj
+++ b/core/src/yamlscript/runtime.clj
@@ -29,6 +29,9 @@
 (def ys-ys (sci/create-ns 'ys))
 (def ys-ys-vars (sci/copy-ns ys.ys ys-ys))
 
+(def clj-str (sci/create-ns 'str))
+(def clj-str-vars (sci/copy-ns clojure.string clj-str))
+
 (def argv (sci/new-dynamic-var 'ARGV nil))
 (def env (sci/new-dynamic-var 'ENV nil))
 
@@ -62,7 +65,15 @@
     'ys.json ys-json-vars
     'ys.yaml ys-yaml-vars
     'ys.ys ys-ys-vars
-    'clojure.core (clojure-core-vars)}})
+    'str clj-str-vars
+    'clojure.core (clojure-core-vars)}
+   :classes
+   {'Boolean java.lang.Boolean
+    'java.lang.Boolean java.lang.Boolean
+    'Character java.lang.Character
+    'java.lang.Character java.lang.Character
+    'Long java.lang.Long
+    'java.lang.Long java.lang.Long}})
 
 (defn ys-load
   ([file]

--- a/ys/test/yamlscript/cli_test.clj
+++ b/ys/test/yamlscript/cli_test.clj
@@ -118,6 +118,14 @@ bar:
     - bbb: 2"
     "Testing the 'load' function to load another YS file")
 
+  (like (ys "-pe" "find-ns: quote(str)")
+    #"sci\.lang\.Namespace"
+    "clojure.string ns available as str")
+
+  (like (ys "-pe" ".[Character Long Double String Boolean]")
+    #"(?s)Character.*Long.*Double.*String.*Boolean"
+    "Standard java classes available")
+
   #__)
 
 (swap! cli/testing (constantly true))


### PR DESCRIPTION
String is there but these are missing:

* Long
* Double
* Boolean
* Character
* Integer
* Float