### PR TITLE
Interpolation not working in string token.

### DIFF
--- a/core/src/yamlscript/builder.clj
+++ b/core/src/yamlscript/builder.clj
@@ -128,9 +128,8 @@
       \$ $bpar
     )"))
 
-(defn build-vstr [node]
-  (let [string (:vstr node)
-        parts (re-seq re-interpolated-string string)
+(defn build-interpolated [string]
+  (let [parts (re-seq re-interpolated-string string)
         exprs (map
                 #(cond
                    (re-matches (re/re #"\$$symw$bpar") %1)
@@ -148,6 +147,21 @@
     (if (= 1 (count exprs))
       (first exprs)
       (Lst (cons (Sym 'str) exprs)))))
+
+(defn build-dq-string [string]
+  (-> string
+    (str/replace #"\\\$" "$")
+    (str/replace #"\\ " " ")
+    (str/replace #"\\n" "\n")
+    Str))
+
+(defn build-vstr [node]
+  (let [string (:vstr node)]
+    (if (re-find #"\$[\(a-zA-Z]" string)
+      (build-interpolated string)
+      (build-dq-string string))))
+
+(reset! yamlscript.util/build-vstr build-vstr)
 
 (defn build-node [node]
   (let [[tag] (first node)]

--- a/core/src/yamlscript/builder.clj
+++ b/core/src/yamlscript/builder.clj
@@ -128,6 +128,13 @@
       \$ $bpar
     )"))
 
+(defn build-exp-interpolated [node]
+  (let [exp (build-exp node)
+        lst1 (:Lst exp)
+        lst2 (get-in lst1 [0 :Lst])
+        exp (if (and (= 1 (count lst1)) lst2) (Lst lst2) exp)]
+    exp))
+
 (defn build-interpolated [string]
   (let [parts (re-seq re-interpolated-string string)
         exprs (map
@@ -139,7 +146,7 @@
                    (Sym (subs %1 1))
                    ,
                    (re-matches (re/re #"\$$bpar") %1)
-                   (build-exp {:exp (subs %1 1)})
+                   (build-exp-interpolated {:exp (subs %1 1)})
                    ,
                    :else
                    (Str (str/replace %1 #"\\(\$)" "$1")))

--- a/core/src/yamlscript/compiler.clj
+++ b/core/src/yamlscript/compiler.clj
@@ -84,32 +84,6 @@
 
 (comment
   www
-; {:do [[{:Sym a} {:Sym b}]]}
-; (:construct {:Lst [{:Sym a} {:Sym b}]})
-  (binding [*debug* stages]
-    (->>
-      "!yamlscript/v0
-foo =: 123
-defn bar(a b):
-  c =: (a + b)
-  .*: 2 c
-bar: 10 20"
-      compile-debug
-      print))
-
-  (-> "" compile)
-  (-> "!yamlscript/v0" compile)
-  (-> "a: b" compile)
-
-  (-> [#__
-       "foo: bar baz"
-       "if (x > y): x (inc y)"
-       "if(x > y): x (inc y)"
-       #__]
-    (nth 2)
-    compile
-    println)
-
   (->> "../test/hello.ys"
     slurp
     compile

--- a/core/src/yamlscript/util.clj
+++ b/core/src/yamlscript/util.clj
@@ -8,13 +8,7 @@
   (:require
    [yamlscript.debug :refer [www]]))
 
-
-(defmacro when-lets
-  ([bindings & body]
-   (if (seq bindings)
-     `(when-let [~(first bindings) ~(second bindings)]
-        (when-lets ~(drop 2 bindings) ~@body))
-     `(do ~@body))))
+(defonce build-vstr (atom nil))
 
 (defmacro if-lets
   ([bindings then]
@@ -25,6 +19,13 @@
         (if-lets ~(drop 2 bindings) ~then ~else)
         ~else)
      then)))
+
+(defmacro when-lets
+  ([bindings & body]
+   (if (seq bindings)
+     `(when-let [~(first bindings) ~(second bindings)]
+        (when-lets ~(drop 2 bindings) ~@body))
+     `(do ~@body))))
 
 (comment
   www)

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -594,3 +594,11 @@
       =>:
   clojure: |
     (foo "bar" "baz" (call) (nada nil))
+
+
+- name: Interpolation in YS strings
+  yamlscript: |
+    !yamlscript/v0
+    =>: 3 * "hi $name\n"
+  clojure: |
+    (_* 3 (str "hi " name "\n"))

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -602,3 +602,11 @@
     =>: 3 * "hi $name\n"
   clojure: |
     (_* 3 (str "hi " name "\n"))
+
+
+- name: Interpolated path lookup
+  yamlscript: |
+    !yamlscript/v0
+    =>: "Hi $(ARGV.0)!!"
+  clojure: |
+    (str "Hi " (__ ARGV 0) "!!")


### PR DESCRIPTION
Works:
```
say: "Hello, $name!"
```
Doesn't work:
```
say: "Hello, $name" + "!"
```
