### PR TITLE
Change ARGV to ARGS and ARGP

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -4,5 +4,7 @@
   org.clojure/data.json {:mvn/version "2.4.0"},
   clj-commons/clj-yaml {:mvn/version "1.0.27"},
   org.snakeyaml/snakeyaml-engine {:mvn/version "2.7"},
+  babashka/fs {:mvn/version "0.5.20"},
+  org.babashka/http-client {:mvn/version "0.3.11"},
   org.babashka/sci {:mvn/version "0.8.41"}},
- :mvn/repos {"public-github" {:url "git://github.com"}}}
+ :mvn/repos {"public-github" {:url "https://github.com"}}}

--- a/core/project.clj
+++ b/core/project.clj
@@ -21,6 +21,8 @@
    [org.clojure/data.json "2.4.0"]
    [clj-commons/clj-yaml "1.0.27"]
    [org.snakeyaml/snakeyaml-engine "2.7"]
+   [babashka/fs "0.5.20"]
+   [org.babashka/http-client "0.3.11"]
    [org.babashka/sci "0.8.41"]]
 
   :plugins
@@ -31,7 +33,7 @@
 
   :prep-tasks [["lein2deps" "--write-file" "deps.edn" "--print" "false"]]
 
-  :repositories [["public-github" {:url "git://github.com"}]]
+  :repositories [["public-github" {:url "https://github.com"}]]
 
   :global-vars {*warn-on-reflection* true}
 


### PR DESCRIPTION
Currently the symbol `ARGV` points to an array of CLI args that are strings, unless the value looks like a number, then it is converted.

We want 2 arrays. One for just strings and one for parsed values.

We'll call then `ARGS` and `ARGP` respectively.