### PR TITLE
Support multi doc with addressing

### DIFF
--- a/.profile
+++ b/.profile
@@ -2,8 +2,10 @@
 
 YAMLSCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd -P)
 
-[[ :$PATH: == *:"$YAMLSCRIPT_ROOT/ys/bin":* ]] ||
-  PATH=$YAMLSCRIPT_ROOT/ys/bin:$PATH
+ys-local() {
+  [[ :$PATH: == *:"$YAMLSCRIPT_ROOT/ys/bin":* ]] ||
+    PATH=$YAMLSCRIPT_ROOT/ys/bin:$PATH
+}
 
 YS() (
   set -e

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,14 @@
 {
   "calva.fmt.configPath": ".cljfmt.edn",
   "cSpell.words": [
+    "arity",
     "concat",
     "cond",
     "condp",
     "debuginfo",
     "defmacro",
     "defn",
+    "defsyn",
     "distclean",
     "doall",
     "fizzbuzz",
@@ -14,11 +16,16 @@
     "isolatethread",
     "libyamlscript",
     "mapv",
+    "nada",
+    "nums",
+    "parens",
+    "println",
     "Raku",
     "serde",
     "unoptimized",
     "vstr",
-    "yamlscript"
+    "yamlscript",
+    "ysexpr"
   ],
   "java.configuration.updateBuildConfiguration": "disabled"
 }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -73,7 +73,7 @@ It has these main modes of operation:
 * `ys --run <file>` - Same as above but explicit
 * `ys --load <file>` - Load a YAMLScript program
 * `ys --compile <file>` - Compile a YAMLScript program to Clojure
-* `ys --native <file>` - Compile YAMLScript to a native binary executable
+* `ys --binary <file>` - Compile YAMLScript to a native binary executable
 * `ys --eval '<expr>'` - Evaluate a YAMLScript expression string
 * `ys --repl` - Start an interactive YAMLScript REPL session
 * `ys --install` - Install the latest libyamlscript shared library

--- a/common/clojure.mk
+++ b/common/clojure.mk
@@ -96,6 +96,8 @@ endif
 
 repl-deps::
 
+nrepl+: nrepl-stop nrepl
+
 nrepl: .nrepl-pid
 	@echo "nREPL server running on port $$(< .nrepl-port)"
 

--- a/core/src/yamlscript/constructor.clj
+++ b/core/src/yamlscript/constructor.clj
@@ -17,7 +17,7 @@
   maybe-call-main
   check-let-bindings)
 
-(defn construct
+(defn construct-ast
   "Construct resolved YAML tree into a YAMLScript AST."
   [node]
   (let [ctx {:lvl 0 :defn false}]
@@ -29,6 +29,15 @@
       (hash-map :Top)
       declare-undefined
       maybe-call-main)))
+
+(defn construct
+  "Make the AST and add wrap the last node."
+  [node]
+  (-> node
+    construct-ast
+    ((fn [m]
+       (update-in m [:Top (dec (count (:Top m)))]
+         (fn [n] (Lst [(Sym '+++) n])))))))
 
 (defn construct-call [[key val]]
   (cond

--- a/core/src/yamlscript/printer.clj
+++ b/core/src/yamlscript/printer.clj
@@ -25,6 +25,14 @@
   (-> s
     (str/escape regex-escape)))
 
+(defn pr-symbol [s]
+  (case s
+    "$" "($)"
+    "$$" "@$$"
+    "$#" "@$#"
+    "=~" "=--"
+    , s))
+
 (defn print-node [node]
   (let [node (if (keyword? node) {node true} node)
         [type val] (first node)]
@@ -51,7 +59,7 @@
       :Rgx (str \# \" (pr-regex val) \")
       :Chr (str "\\" val)
       :Spc (str/replace val #"::" ".")
-      :Sym (str (str/replace val #"~" "--"))
+      :Sym (pr-symbol (str val))
       :Tok (str val)
       :Key (str val)
       :Int (str val)

--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -47,7 +47,7 @@
               [\s,]+    |                    # whitespace, commas,
               ;.*\n?                         # comments
             )")
-(def dotn #"(?:\.\d+)")                    ; Dot operator followed by number
+(def dotn #"(?:\.-?\d+)")                  ; Dot operator followed by number
 (def mnum #"(?:[-+]?\d[-+/*%.:\w]+)")      ; Maybe Number token
 (def inum #"-?\d+")                        ; Integer literal token
 (def fnum (re #"$inum\.\d*(?:e$inum)?"))   ; Floating point literal token
@@ -70,7 +70,7 @@
             )*\"                             # Ending quote
             ")
 (def sstr #"(?x)
-            '(?:                          # Single quoted string
+            '(?:                           # Single quoted string
               '' |                           # Escaped single quote
               [^']                           # Any other char
             )*'                              # Ending quote
@@ -78,7 +78,8 @@
 (def pnum #"(?:\d+)")                      ; Positive integer
 (def anum #"[a-zA-Z0-9]")                  ; Alphanumeric
 (def symw (re #"(?:$anum+(?:-$anum+)*)"))  ; Symbol word
-(def vsym (re #"(?:\$$symw)"))             ; Dollar sign symbol
+(def vsym (re #"(?:\$$symw)"))             ; Variable lookup symbol
+(def ssym (re #"(?:\$\$|\$\#|\$)"))        ; Special symbols
 (def keyw (re #"(?:\:$symw)"))             ; Keyword token
                                            ; Clojure symbol
 (def csym #"(?:[-a-zA-Z0-9_*+?!<=>$]+(?:\.(?=\ ))?)")
@@ -90,9 +91,9 @@
 (def psym (re #"(?:(?:$fsym|$ysym)\()"))
 (def esym (re #"(?:\*$symw\*)"))           ; Earmuff symbol
 
-(def defk (re #"(?:\[.*\]|\{.*\}|$symw) +="))                ; Pair key for def/let call
-(def dfnk (re #"^defn ($ysym)(?:\((.*)\))?$"))  ; Pair key for defn call
-(def afnk (re #"^fn ($ysym)(?:\((.*)\))?$"))  ; Pair key for a fn call
+(def defk (re #"(?:\[.*\]|\{.*\}|$symw) +="))  ; Pair key for def/let call
+(def dfnk (re #"^defn ($ysym)(?:\((.*)\))?$")) ; Pair key for defn call
+(def afnk (re #"^fn ($ysym)(?:\((.*)\))?$"))   ; Pair key for a fn call
 
 ; Balanced parens
 (def bpar #"(?x)

--- a/core/src/yamlscript/runtime.clj
+++ b/core/src/yamlscript/runtime.clj
@@ -26,15 +26,23 @@
 (def ARGV (sci/new-dynamic-var 'ARGV))
 (def INC (sci/new-dynamic-var 'INC))
 
+;; Define the clojure.core namespace that is referenced into all namespaces
 (defn clojure-core-ns []
-  (let [core {'ARGS ARGS
+  (let [core {;; Runtime variables
+              'ARGS ARGS
               'ARGV ARGV
+              'CWD nil
+              'ENV nil
               'FILE ys/FILE
               'INC INC
+              'VERSION nil
+              'VERSIONS nil
 
+              ;; clojure.core functions overridden by YS
               'load (sci/copy-var ys.ys/load-file nil)
               'use (sci/copy-var ys.ys/use nil)
 
+              ;; clojure.core functions not added by SCI
               'parse-double (sci/copy-var clojure.core/parse-double nil)
               'parse-long (sci/copy-var clojure.core/parse-long nil)
               'pprint (sci/copy-var clojure.pprint/pprint nil)
@@ -113,7 +121,8 @@
          INC (get-yspath file)]
          (sci/eval-string* @ys/sci-ctx clj))))))
 
+(sci/intern @ys/sci-ctx 'clojure.core 'eval-string eval-string)
+
 (comment
   www
-  (eval-string "(say (inc 123))")
   )

--- a/core/src/yamlscript/ysreader.clj
+++ b/core/src/yamlscript/ysreader.clj
@@ -74,7 +74,8 @@
     (re-matches re/fsym (str token))
     (re-matches re/esym (str token))
     (re-matches re/ysym (str token))
-    (re-matches re/vsym (str token))))
+    (re-matches re/vsym (str token))
+    (re-matches re/ssym (str token))))
 
 (defn is-default-symbol? [token]
   (re-matches re/dsym (str token)))
@@ -97,7 +98,8 @@
       $regx |                   # Regex token
       $xsym |                   # Special operators (=~ etc)
       $dsym |                   # Symbol with default
-      $vsym |                   # Dollar sign symbol
+      $vsym |                   # Variable lookup symbol
+      $ssym |                   # Special symbols
       $csym |                   # Clojure symbol
       $narg |                   # Numbered argument token
       $dotn |                   # Dot operator followed by number
@@ -130,9 +132,12 @@
 
 (defn- qf [form]
   (cond
-    (:Sym form) (if (re-find #"^\$" (-> form :Sym str))
-                  (Sym (-> form :Sym str  (subs 1)))
-                  (Lst [(Sym 'quote) form]))
+    (:Sym form) (let [sym (-> form :Sym str)]
+                  (if (re-find #"^\$\w" sym)
+                    (Sym (subs sym 1))
+                    (if (= sym "$#")
+                      form
+                      (Lst [(Sym 'quote) form]))))
     (:Lst form) (Lst [(Sym 'quote) form])
     :else form))
 

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -397,15 +397,15 @@
             \(line width, %1): (width..1)
   clojure: |
     (defn
-     tree
-     [width]
-     (let
-      [stars
-       (fn [& [_1]] (_* (inc _1) "*"))
-       spaces
-       (fn [& [_1]] (_* _1 " "))
-       top
-       (join (map ((fn [& [_1]] (line width _1)) (rng width 1))))]))
+      tree
+      [width]
+      (let
+       [stars
+        (fn [& [_1]] (_* (inc _1) "*"))
+        spaces
+        (fn [& [_1]] (_* _1 " "))
+        top
+        (join (map ((fn [& [_1]] (line width _1)) (rng width 1))))]))
 
 
 - name: Star operator in anonymous function
@@ -624,7 +624,7 @@
     (str "Hi " (__ ARGS 0) "!!")
 
 
-- name: Floatings point numbers
+- name: Floating point numbers
   yamlscript: |
     !yamlscript/v0
     =>: .[ 0. 0.1 -1.2e3 2.3e-4 ]
@@ -681,9 +681,9 @@
       =>: a + b + c
   clojure: |
     (defn
-     foo
-     []
-     (let [[a b c] [1 2 3] {:d d, :e e} {:d 4, :e 5}] (_+ a b c)))
+      foo
+      []
+      (let [[a b c] [1 2 3] {:d d, :e e} {:d 4, :e 5}] (_+ a b c)))
 
 
 - name: Destructuring def not allowed
@@ -798,3 +798,18 @@
     =>: a.b.$c.d(e)
   clojure: |
     (__ a 'b c '(d e))
+
+
+- name: Multiple document stream
+  yamlscript: |
+    foo: 42
+    --- !yamlscript/v0
+    =>::
+      bar:: _.foo.inc()
+      foo: 123
+    ---
+    bar: 44
+  clojure: |
+    {"foo" 42}
+    {"bar" (__ _ 'foo '(inc)), "foo" 123}
+    {"bar" 44}

--- a/core/test/transformer.yaml
+++ b/core/test/transformer.yaml
@@ -68,12 +68,12 @@
       foo::fff: :all
   clojure: |
     (require
-     '[foo.aaa :as fa]
-     '[foo.bbb :refer [one]]
-     '[foo.ccc :refer [one two]]
-     '[foo.ddd :as fd :refer [one two]]
-     'foo.eee
-     '[foo.fff :refer :all])
+      '[foo.aaa :as fa]
+      '[foo.bbb :refer [one]]
+      '[foo.ccc :refer [one two]]
+      '[foo.ddd :as fd :refer [one two]]
+      'foo.eee
+      '[foo.fff :refer :all])
 
 
 - name: Anonymous function with name

--- a/core/test/yamlscript/builder_test.clj
+++ b/core/test/yamlscript/builder_test.clj
@@ -9,7 +9,8 @@
    [yamlscript.composer :as composer]
    [yamlscript.resolver :as resolver]
    [yamlscript.builder :as builder]
-   [yamltest.core :as test]))
+   [yamltest.core :as test]
+   [yamlscript.debug :refer [www]]))
 
 (test/load-yaml-test-files
   ["test/compiler-stack.yaml"

--- a/core/test/yamlscript/compiler_test.clj
+++ b/core/test/yamlscript/compiler_test.clj
@@ -4,8 +4,15 @@
 (ns yamlscript.compiler-test
   #_(:use yamlscript.debug)
   (:require
+   [clojure.string :as str]
    [yamlscript.compiler :as compiler]
-   [yamltest.core :as test]))
+   [yamltest.core :as test]
+   [yamlscript.debug :refer [www]]))
+
+(defn testing-fix-clojure [clj]
+  (-> clj
+    (str/replace #"(?m)^\(\+\+\+ +(.*)\)$" "$1")
+    (str/replace #"(?s)^\(\+\+\+[ \n]+(.*)\)$" "$1")))
 
 (test/load-yaml-test-files
   ["test/compiler.yaml"
@@ -16,7 +23,8 @@
            (->> test
              :yamlscript
              compiler/compile
-             compiler/pretty-format))
+             compiler/pretty-format
+             testing-fix-clojure))
    :want :clojure})
 
 (test/load-yaml-test-files

--- a/core/test/yamlscript/constructor_test.clj
+++ b/core/test/yamlscript/constructor_test.clj
@@ -26,7 +26,7 @@
              resolver/resolve
              builder/build
              transformer/transform
-             constructor/construct))
+             constructor/construct-ast))
    :want (fn [test]
            (->> test
              :construct

--- a/core/test/yamlscript/parser_test.clj
+++ b/core/test/yamlscript/parser_test.clj
@@ -16,7 +16,7 @@
    :test (fn [test]
            (->> test
              :yamlscript
-             parser/parse
+             parser/parse-test-case
              (map pr-str)
              (map #(subs %1 4 (dec (count %1))))))
    :want (fn [test]

--- a/core/test/yamlscript/printer_test.clj
+++ b/core/test/yamlscript/printer_test.clj
@@ -27,7 +27,7 @@
              resolver/resolve
              builder/build
              transformer/transform
-             constructor/construct
+             constructor/construct-ast
              printer/print
              compiler/pretty-format))
    :want :print})

--- a/libyamlscript/src/libyamlscript/core.clj
+++ b/libyamlscript/src/libyamlscript/core.clj
@@ -5,8 +5,8 @@
 
 (ns libyamlscript.core
   (:require
-   [yamlscript.compiler :as ys]
-   [yamlscript.runtime :as run]
+   [yamlscript.compiler :as compiler]
+   [yamlscript.runtime :as runtime]
    [clojure.data.json :as json]
    [sci.core :as sci])
   (:gen-class
@@ -32,8 +32,8 @@
   (sci/binding [sci/out *out*]
     (try
       (->> ys-str
-        ys/compile
-        run/eval-string
+        compiler/compile
+        runtime/eval-string
         (assoc {} :data)
         json-write-str)
 

--- a/ys/Makefile
+++ b/ys/Makefile
@@ -36,7 +36,7 @@ test: test-unit
 
 test-all: test-unit test-ys
 
-test-unit: $(LEIN)
+test-unit: $(LEIN) $(YAMLSCRIPT_LANG_INSTALLED)
 	$< test
 
 test-ys: $(YAMLSCRIPT_CLI_BIN)

--- a/ys/share/ys-0.bash
+++ b/ys/share/ys-0.bash
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+[[ ${YS_SH_DEBUG-} ]] && set -x
+
 yamlscript_version=0.1.38
 
 main() (
@@ -21,7 +23,7 @@ do-upgrade() (
   curl -sSL https://yamlscript.org/install | bash
 )
 
-do-compile-to-native() (
+do-compile-to-binary() (
   in_file=${1-}
   out_file=${2-}
   ys_version=${3-}
@@ -30,7 +32,7 @@ do-compile-to-native() (
      $ys_version &&
      ( $in_file == NO-NAME.ys || -f $in_file )
    ]] ||
-    die "Usage: --compile-to-native <in-file> <out-file> <ys-version>"
+    die "Usage: --compile-to-binary <in-file> <out-file> <ys-version>"
   [[ $in_file == *.ys ]] ||
     die "File '$in_file' must have .ys extension"
 
@@ -136,7 +138,7 @@ write-program-clj() (
   fi
 
   n=$'\n'
-  [[ $program =~ (^|$n)\(defn[\ $n]+main[\ $n] ]] ||
+  [[ $program =~ \(defn[\ $n]+main[\ $n] ]] ||
     die "Could not find main function in '$in_file'"
 
   cat <<EOF > src/program.clj
@@ -162,8 +164,8 @@ EOF
 
 write-profile() (
   cat > project.clj <<EOF
-(defproject program "ys-native"
-  :description "Compile a YAMLScript program to native machine code"
+(defproject program "ys-binary"
+  :description "Compile a YAMLScript program to native binary executable"
 
   :dependencies
   [[org.clojure/clojure "1.11.1"]
@@ -200,7 +202,7 @@ SHELL := bash
 
 export PATH := /tmp/graalvm-oracle-21/bin:$(PATH)
 
-JAR := target/uberjar/program-ys-native-standalone.jar
+JAR := target/uberjar/program-ys-binary-standalone.jar
 
 OPTIONS := \
   -O1 \

--- a/ys/test/test.sh
+++ b/ys/test/test.sh
@@ -48,9 +48,11 @@ ys -c -e 'say: "Hello, World!"' \
       -e 'say: "YAMLScript!!"' \
       "$ROOT/test/hello.ys"
 
-ys -c -x parse -x build -x print -e 'say: "Hello, World!"'
+ys -c -D parse -D build -D print -e 'say: "Hello, World!"'
 
-ys -x all -e 'say: inc(41)'
+ys -D all -e 'say: inc(41)'
+
+ys -d -e 'say: inc(41)'
 
 echo 42 | ys -E
 

--- a/ys/test/yamlscript/cli_test.clj
+++ b/ys/test/yamlscript/cli_test.clj
@@ -18,24 +18,24 @@
 (test/deftest cli-test
 
   (has (ys)
-    "Usage: ys [options] [file]"
+    "Usage: ys [<option...>] [<file>]"
     "No args prints help")
 
   (has (ys "-h")
-    "Usage: ys [options] [file]"
+    "Usage: ys [<option...>] [<file>]"
     "-h prints help")
 
   (has (ys "--help")
-    "Usage: ys [options] [file]"
+    "Usage: ys [<option...>] [<file>]"
     "--help prints help")
 
   (like (ys "--version")
     #"^YAMLScript \d+\.\d+\.\d+$"
     "--version prints version")
 
-  (is (ys "-le" "a: b")
+  (is (ys "-mb" "-le" "a: b")
     "{\"a\":\"b\"}"
-    "-l uses bare mode and prints json")
+    "-l with bare mode")
 
   (is (ys "-e" "say: \"Hello\"")
     "Hello"
@@ -61,7 +61,7 @@
     #"std.say"
     "'say' evaluates to a symbol")
 
-  (is (ys "-ce" "std/say: 123")
+  (has (ys "-ce" "std/say: 123")
     "(std/say 123)"
     "-c prints Clojure code of compilation")
 


### PR DESCRIPTION
Currently YS only supports YAML streams with a single document.

We can support multiple documents.
Each evaluated sequentially. 
A load operation would produce the value of the final document.

From any document evaluation you can access data from a previously evaluated document in the stream with a special symbol.
Maybe `^` or `$` or `*` or `%`. 
Let's use `^` for now.

In the third document, `^1` points to the second (previous document) and `^2` points to the first and `^3` or higher returns `nil`.
`^` is an alias for `^1`.

The ys CLI will be changed to evaluate `-e` expressions after any file evaluation.
Then one can use `ys` like `jq` applying YS path syntax like so:
```
ys --load file.ys -e '^.foo.bar'
```

Another symbol `^^` points to a vector of all currently evaluated documents.
Thus `^^.0` is the first document and `^^.last()` would be the current last one.