### PR TITLE
Backslash as generic meta, change character literal syntax

### DIFF
--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -11,7 +11,7 @@
   (:require
    [clojure.string :as str]
    [yamlscript.debug :refer [www]])
-  (:refer-clojure :exclude [char]))
+  (:refer-clojure :exclude [char quot]))
 
 (defn re [rgx]
   (loop [rgx (str rgx)]
@@ -47,6 +47,7 @@
               [\s,]+    |                    # whitespace, commas,
               ;.*\n?                         # comments
             )")
+(def quot #"(?:\\')")                      ; Quote token
 (def dotn #"(?:\.-?\d+)")                  ; Dot operator followed by number
 (def mnum #"(?:[-+]?\d[-+/*%.:\w]+)")      ; Maybe Number token
 (def inum #"-?\d+")                        ; Integer literal token

--- a/core/src/yamlscript/re.clj
+++ b/core/src/yamlscript/re.clj
@@ -29,7 +29,7 @@
         (re-pattern rgx)))))
 
 (def char #"(?x)
-            \\
+            \\\\
             (?:
               newline |
               space |

--- a/core/src/yamlscript/runtime.clj
+++ b/core/src/yamlscript/runtime.clj
@@ -77,11 +77,13 @@
      {'Boolean   java.lang.Boolean
       'Character java.lang.Character
       'Long      java.lang.Long
+      'Math      java.lang.Math
       'Thread    java.lang.Thread
 
       'java.lang.Boolean   java.lang.Boolean
       'java.lang.Character java.lang.Character
       'java.lang.Long      java.lang.Long
+      'java.lang.Math      java.lang.Math
       'java.lang.Thread    java.lang.Thread}}))
 
 (sci/intern @ys/sci-ctx 'clojure.core 'CWD (str (babashka.fs/cwd)))

--- a/core/src/yamlscript/transformer.clj
+++ b/core/src/yamlscript/transformer.clj
@@ -19,7 +19,7 @@
 
 (defn map-vec [f coll] (->> coll (map f) vec))
 
-(defn add-num-or-string [{list :Lst}]
+#_(defn add-num-or-string [{list :Lst}]
   (when (and
           (>= (count list) 3)
           (= (first list) {:Sym '+}))
@@ -27,7 +27,7 @@
           [_ & rest] list]
       {:Lst (cons {:Sym '_+} rest)})))
 
-(defn string-repeat [{list :Lst}]
+#_(defn string-repeat [{list :Lst}]
   (when (and
           (= (count list) 3)
           (= (first list) {:Sym '*}))
@@ -66,8 +66,8 @@
 
 (defn transform-list [node]
   (or
-    (add-num-or-string node)
-    (string-repeat node)
+    ; (add-num-or-string node)
+    ; (string-repeat node)
     ;(if (= 'fn (get-in node [:Lst 0 :Sym]))
     (if (:Lst node)
       {:Lst (map-vec transform-node (:Lst node))}

--- a/core/src/yamlscript/ysreader.clj
+++ b/core/src/yamlscript/ysreader.clj
@@ -171,6 +171,8 @@
 (def operators
   {(Sym '.)  (Sym '__)
    (Sym '..) (Sym 'rng)
+   (Sym '+) (Sym '_+)
+   (Sym '*) (Sym '_*)
    (Sym '||) (Sym 'or)
    (Sym '&&) (Sym 'and)
    (Sym '%)  (Sym 'rem)
@@ -190,11 +192,7 @@
                    (apply = %1))
             (map Sym '[+ - * / || && .])))
       (let [op (second expr)
-            op (cond
-                 (= op (Sym '.))  (Sym '__)
-                 (= op (Sym '||)) (Sym 'or)
-                 (= op (Sym '&&)) (Sym 'and)
-                 :else op)]
+            op (or (operators op) op)]
         (->> expr
           (cons nil)
           (partition 2)

--- a/core/src/yamlscript/ysreader.clj
+++ b/core/src/yamlscript/ysreader.clj
@@ -93,6 +93,7 @@
       $comm |                 # Comment
                               # Symbols and operators
       $quot |                   # Quote token
+      $char |                   # Character token
       $keyw |                   # Keyword token
       $esym |                   # Earmuff symbol
       $psym |                   # Symbol followed by paren
@@ -108,7 +109,6 @@
       $narg |                   # Numbered argument token
       $dotn |                   # Dot operator followed by number
       $osym |                   # Operator symbol token
-      $char |                   # Character token
       $anon |                   # Anonymous fn start token
       $dstr |                 # String token
       $sstr |                 # String token
@@ -301,7 +301,7 @@
     (is-string? token) [(read-dq-string token) tokens]
     (is-single? token) [(read-sq-string token) tokens]
     (is-keyword? token) [(Key (subs token 1)) tokens]
-    (is-character? token) [(Chr (subs token 1)) tokens]
+    (is-character? token) [(Chr (subs token 2)) tokens]
     (is-regex? token) [(Rgx (subs token 1 (dec (count token)))) tokens]
 
     (is-fq-symbol? token)

--- a/core/src/yamlscript/ysreader.clj
+++ b/core/src/yamlscript/ysreader.clj
@@ -48,6 +48,9 @@
 (defn is-operator? [token]
   (re-matches re/osym (str token)))
 
+(defn is-quote? [token]
+  (re-matches re/quot (str token)))
+
 (defn is-syntax-quote? [token]
   (= "`" (str token)))
 
@@ -89,6 +92,7 @@
     (?:
       $comm |                 # Comment
                               # Symbols and operators
+      $quot |                   # Quote token
       $keyw |                   # Keyword token
       $esym |                   # Earmuff symbol
       $psym |                   # Symbol followed by paren
@@ -275,6 +279,8 @@
     (= "nil" token) [(Nil) tokens]
     (= "true" token) [(Bln token) tokens]
     (= "false" token) [(Bln token) tokens]
+    (is-quote? token) (let [[value tokens] (read-form tokens)]
+                        [(Lst [(Sym 'quote) value]) tokens])
     (is-narg? token) (let [n (subs token 1)
                            n (parse-long n)
                            _ (when (or (<= n 0) (> n 20))

--- a/core/test/compiler-stack.yaml
+++ b/core/test/compiler-stack.yaml
@@ -157,7 +157,7 @@
 - name: YS reader forms
   yamlscript: |
     --- !yamlscript/v0
-    prn: .["str" \c 42 foo true false nil]
+    prn: .["str" \\c 42 foo true false nil]
     prn: .{:a 1 :c 2 :b 3}
     prn: ."A longer string"
   build: |

--- a/core/test/compiler-stack.yaml
+++ b/core/test/compiler-stack.yaml
@@ -194,7 +194,7 @@
   build: |
     {:pairs
      [{:Sym inc}
-      {:Lst [{:Sym *} {:Int 6} {:Int 7}]}]}
+      {:Lst [{:Sym _*} {:Int 6} {:Int 7}]}]}
   print: |
     (inc (_* 6 7))
 
@@ -237,7 +237,7 @@
   build: |
     {:pairs
      [[{:Sym defn} {:Sym foo} nil {:Vec [{:Sym a} {:Sym b}]}]
-      {:Lst [{:Sym +} {:Sym a} {:Sym b}]}]}
+      {:Lst [{:Sym _+} {:Sym a} {:Sym b}]}]}
   print: |
     (defn foo [a b] (_+ a b))
 
@@ -310,9 +310,9 @@
       [{:Sym defn} {:Sym bar} nil {:Vec [{:Sym a} {:Sym b}]}]
       {:pairs
        ([{:Sym def} {:Sym c}]
-        {:Lst [{:Sym +} {:Sym a} {:Sym b}]}
+        {:Lst [{:Sym _+} {:Sym a} {:Sym b}]}
         {:Sym =>}
-        {:Lst [{:Sym *} {:Int 2} {:Sym c}]})}
+        {:Lst [{:Sym _*} {:Int 2} {:Sym c}]})}
       {:Sym bar}
       [{:Int 10} {:Int 20}])}
   print: |
@@ -442,7 +442,7 @@
      ([{:Sym def} {:Sym x}]
       {:Str "a\nb"}
       [{:Sym def} {:Sym y}]
-      {:Lst [{:Sym +} {:Str "c"} {:Str "d\ne"}]})}
+      {:Lst [{:Sym _+} {:Str "c"} {:Str "d\ne"}]})}
 
 
 - name: fn special form

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -337,7 +337,7 @@
        {:Vec
         [{:Sym &}
          {:Vec [{:Sym _1} {:Sym _} {:Sym _} {:Sym _4}]}]}
-       {:Lst [{:Sym +} {:Sym _1} {:Sym _4}]}]})}
+       {:Lst [{:Sym _+} {:Sym _1} {:Sym _4}]}]})}
   clojure: |
     (def foo (fn [& [_1 _ _ _4]] (_+ _1 _4)))
 
@@ -829,3 +829,13 @@
     (_+ [foo] [bar])
     (_+ {foo 1} {bar 2})
     (foo || bar)
+
+
+- name: Star in the middle
+  yamlscript: |
+    !yamlscript/v0
+    =>: a * b
+    =>: a(* b)
+  clojure: |
+    (_* a b)
+    (a * b)

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -839,3 +839,13 @@
   clojure: |
     (_* a b)
     (a * b)
+
+
+- name: Quote escaping
+  yamlscript: |
+    !yamlscript/v0
+    =>: \'(1 2 3)
+    =>: \'foo
+  clojure: |
+    '(1 2 3)
+    'foo

--- a/core/test/compiler.yaml
+++ b/core/test/compiler.yaml
@@ -849,3 +849,11 @@
   clojure: |
     '(1 2 3)
     'foo
+
+
+- name: Char escaping
+  yamlscript: |
+    !yamlscript/v0
+    =>: \'( \\a \\5 \\newline \\tab )
+  clojure: |
+    '(\a \5 \newline \tab)

--- a/core/test/runtime.yaml
+++ b/core/test/runtime.yaml
@@ -1,0 +1,37 @@
+# Copyright 2023-2024 Ingy dot Net
+# This code is licensed under MIT license (See License for details)
+
+
+- name: Atoms
+  ys: |
+    vector:
+      =>: 1
+      =>: 2.3
+      =>: "foo"
+      =>: true
+      =>: false
+      =>: .[1 2 3]
+      =>: .{:a 1 :b 2}
+  eval: |
+    [1 2.3 "foo" true false [1 2 3] {:a 1, :b 2}]
+
+
+- name: Operator + combinations
+  ys: |
+    vector:
+      =>: 1 + 2
+      =>: 1 + 2 + 3
+      =>: ."foo" + "bar"
+      =>: .[1 2] + [3 4]
+  eval: |
+    [3 6 "foobar" (1 2 3 4)]
+
+
+- name: Dot threading
+  ys: |
+    n =: 10
+    =>: n.inc().vector().repeat(3 _)
+         .flatten().repeat(2 _)
+         .flatten().take(5 _)
+  eval: |
+    [11 11 11 11 11]

--- a/core/test/yamlscript/runtime_test.clj
+++ b/core/test/yamlscript/runtime_test.clj
@@ -1,0 +1,24 @@
+; Copyright 2023-2024 Ingy dot Net
+; This code is licensed under MIT license (See License for details)
+
+(ns yamlscript.runtime-test
+  (:use yamlscript.debug)
+  (:require
+   [clojure.edn :as edn]
+   [yamlscript.compiler :as compiler]
+   [yamlscript.runtime :as runtime]
+   [yamltest.core :as test]))
+
+(test/load-yaml-test-files
+  ["test/runtime.yaml"]
+  {:pick #(test/has-keys? [:ys :eval] %1)
+   :test (fn [test]
+           (-> test
+             :ys
+             (->> (str "!yamlscript/v0\n"))
+             compiler/compile
+             runtime/eval-string))
+   :want (fn [test]
+           (-> test
+             :eval
+             edn/read-string))})

--- a/sample/rosetta-code/100-doors.ys
+++ b/sample/rosetta-code/100-doors.ys
@@ -3,7 +3,7 @@
 defn main():
   say: |-
     Open doors after 100 passes:
-    $(apply str interpose(', ' open-doors()))
+    $(apply str open-doors().interpose(', ' _))
 
 defn open-doors():
   for [[d n] map(vector doors() iterate(inc 1)) :when d]:


### PR DESCRIPTION
We want to use `\<char>` for various meta meanings.

Clojure only uses it for character literals which are often seen in code.

Change `\a` to `\'a'`, `\tab` to `\'tab'` etc