### PR TITLE
Preserve key order in YAML mapping output

### DIFF
--- a/.version.sh
+++ b/.version.sh
@@ -41,11 +41,15 @@ bump ys/project.clj
 pattern='(YAMLSCRIPT.*)'"$vp"'(.*)'
 
 bump common/install.mk
-bump raku/lib/YAMLScript.rakumod
-bump ruby/lib/yamlscript.rb
-bump www/src/install
 bump java/Makefile
 bump java/src/main/java/org/yamlscript/yamlscript/YAMLScript.java
+bump raku/lib/YAMLScript.rakumod
+bump ruby/lib/yamlscript.rb
+bump www/src/index.md
+bump www/src/install
+bump www/src/posts/advent-2023/dec-05.md
+bump www/src/posts/advent-2023/dec-07.md
+
 
 pattern='(YAMLScript.*)'"$vp"'(.*)'
 

--- a/clojure/src/yamlscript/core.clj
+++ b/clojure/src/yamlscript/core.clj
@@ -8,5 +8,5 @@
   (let [result (json/read-str (.getRAWResult (YAMLScript.) ys-code))
         error (result "error")]
     (if error
-      (throw (Exception. error))
+      (throw (Exception. (error "cause")))
       (result "data"))))

--- a/clojure/src/yamlscript/core.clj
+++ b/clojure/src/yamlscript/core.clj
@@ -1,3 +1,6 @@
+;; Copyright 2023-2024 Ingy dot Net
+;; This code is licensed under MIT license (See License for details)
+
 (ns yamlscript.core
   (:require
    [clojure.data.json :as json])

--- a/clojure/src/yamlscript/core.clj
+++ b/clojure/src/yamlscript/core.clj
@@ -9,7 +9,10 @@
 
 (defn load [ys-code]
   (let [result (json/read-str (.getRAWResult (YAMLScript.) ys-code))
+        data (result "data")
         error (result "error")]
-    (if error
-      (throw (Exception. (error "cause")))
-      (result "data"))))
+    (cond
+      error (throw (Exception. (error "cause")))
+      data data
+      :else (throw
+              (Exception. "Unexpected response from 'libyamlscript'")))))

--- a/common/project.clj
+++ b/common/project.clj
@@ -18,7 +18,6 @@
    [org.clojure/data.json "2.4.0"]
    [org.clojure/tools.gitlibs "1.0.100"]
    [org.clojure/tools.reader "1.3.6"]
-   [org.flatland/ordered "1.15.10"]
    [org.flatland/ordered "1.15.11"]
    [org.slf4j/slf4j-api "1.7.36"]
    [org.snakeyaml/snakeyaml-engine "2.6"]

--- a/core/deps.edn
+++ b/core/deps.edn
@@ -3,6 +3,7 @@
  {org.clojure/clojure {:mvn/version "1.11.1"},
   org.clojure/data.json {:mvn/version "2.4.0"},
   clj-commons/clj-yaml {:mvn/version "1.0.27"},
+  org.flatland/ordered {:mvn/version "1.15.11"},
   org.snakeyaml/snakeyaml-engine {:mvn/version "2.7"},
   babashka/babashka.pods {:mvn/version "0.2.0"},
   babashka/fs {:mvn/version "0.5.20"},

--- a/core/project.clj
+++ b/core/project.clj
@@ -20,6 +20,7 @@
   [[org.clojure/clojure "1.11.1"]
    [org.clojure/data.json "2.4.0"]
    [clj-commons/clj-yaml "1.0.27"]
+   [org.flatland/ordered "1.15.11"]
    [org.snakeyaml/snakeyaml-engine "2.7"]
    [babashka/babashka.pods "0.2.0"]
    [babashka/fs "0.5.20"]

--- a/core/src/yamlscript/common.clj
+++ b/core/src/yamlscript/common.clj
@@ -5,7 +5,7 @@
   (:require
    [yamlscript.debug :refer [www]]))
 
-(def opts (atom nil))
+(def opts (atom {}))
 
 (comment
   www)

--- a/core/src/yamlscript/printer.clj
+++ b/core/src/yamlscript/printer.clj
@@ -7,6 +7,7 @@
 (ns yamlscript.printer
   (:require
    [clojure.string :as str]
+   [yamlscript.common :as common]
    [yamlscript.debug :refer [www]])
   (:refer-clojure :exclude [print]))
 
@@ -50,15 +51,18 @@
              "["
              (str/join " " (map print-node val))
              "]")
-      :Map (str
-             "{"
-             (str/join ", " (->> val
-                              (partition 2)
-                              (map #(str
-                                      (print-node (first %1))
-                                      " "
-                                      (print-node (second %1))))))
-             "}")
+      :Map (let [[start end] (if (:ordered @common/opts)
+                               ["(omap" ")"]
+                               ["{" "}"])]
+             (str
+               start
+               (str/join ", " (->> val
+                                (partition 2)
+                                (map #(str
+                                        (print-node (first %1))
+                                        " "
+                                        (print-node (second %1))))))
+               end))
       :Str (str \" (pr-string val) \")
       :Rgx (str \# \" (pr-regex val) \")
       :Chr (str "\\" val)

--- a/core/src/ys/std.clj
+++ b/core/src/ys/std.clj
@@ -11,6 +11,7 @@
    [babashka.process :as process]
    [clojure.pprint :as pp]
    [clojure.string :as str]
+   [flatland.ordered.map]
    [sci.core :as sci]
    [ys.ys :as ys]
    [yamlscript.util :as util])
@@ -165,6 +166,9 @@
     (if (= 1 (count xs))
       (str/join sep (first xs))
       (str/join sep xs))))
+
+(defn omap [& xs]
+  (apply flatland.ordered.map/ordered-map xs))
 
 (defn out [& xs]
   (apply clojure.core/print xs)

--- a/java/src/main/java/org/yamlscript/yamlscript/LibYAMLScript.java
+++ b/java/src/main/java/org/yamlscript/yamlscript/LibYAMLScript.java
@@ -1,3 +1,6 @@
+// Copyright 2023-2024 Ingy dot Net
+// This code is licensed under MIT license (See License for details)
+
 package org.yamlscript.yamlscript;
 
 import com.sun.jna.Native;

--- a/java/src/main/java/org/yamlscript/yamlscript/LibYAMLScript.java
+++ b/java/src/main/java/org/yamlscript/yamlscript/LibYAMLScript.java
@@ -18,7 +18,8 @@ public class LibYAMLScript {
 
     public static String filename()
     {
-        return "libyamlscript." + extension() + '.' + YAMLScript.YAMLSCRIPT_VERSION;
+        return "libyamlscript." + extension() + '.' +
+               YAMLScript.YAMLSCRIPT_VERSION;
     }
 
     public static String[] libraryPaths()
@@ -42,11 +43,18 @@ public class LibYAMLScript {
         if (path != null) return path;
 
         path = "/usr/local/lib" + pathDelimiter() + name;
-        if (new File(path).exists()) {
-            return path;
-        }
+        if (new File(path).exists()) return path;
 
-        throw new RuntimeException("Shared library file " + name + " not found");
+        path = System.getenv("HOME") + pathDelimiter() +
+               ".local/lib" + pathDelimiter() + name;
+        if (new File(path).exists()) return path;
+
+        throw new RuntimeException(
+            "Shared library file " + name + " not found\n" +
+            "Try: curl -sSL yamlscript.org/install | VERSION=" +
+            YAMLScript.YAMLSCRIPT_VERSION + " LIB=1 bash\n" +
+            "See: https://github.com/yaml/yamlscript/wiki/Installing-YAMLScript"
+        );
     }
 
     public static ILibYAMLScript load(String path)
@@ -68,4 +76,3 @@ public class LibYAMLScript {
         return INSTANCE;
     }
 }
-

--- a/perl/lib/YAMLScript.pm
+++ b/perl/lib/YAMLScript.pm
@@ -93,8 +93,9 @@ $ffi->attach(
 #------------------------------------------------------------------------------
 # Look for the local libyamlscript first, then look for the Alien version:
 sub find_libyamlscript {
+    my $vers = $libyamlscript_version;
     my $so = $^O eq 'darwin' ? 'dylib' : 'so';
-    my $name = "libyamlscript.$so.$libyamlscript_version";
+    my $name = "libyamlscript.$so.$vers";
     my @paths;
     if (my $path = $ENV{LD_LIBRARY_PATH}) {
         @paths = split /:/, $path;
@@ -119,8 +120,11 @@ sub find_libyamlscript {
         }
     }
 
-    die "Unable to find $name";
+    die <<"..."
+Shared library file $name not found
+Try: curl -sSL yamlscript.org/install | VERSION=$vers LIB=1 bash
+See: https://github.com/yaml/yamlscript/wiki/Installing-YAMLScript
+...
 }
-
 
 1;

--- a/perl/lib/YAMLScript.pm
+++ b/perl/lib/YAMLScript.pm
@@ -1,3 +1,6 @@
+# Copyright 2023-2024 Ingy dot Net
+# This code is licensed under MIT license (See License for details)
+
 use strict;
 use warnings;
 

--- a/python/lib/yamlscript/__init__.py
+++ b/python/lib/yamlscript/__init__.py
@@ -60,7 +60,11 @@ def find_libyamlscript_path():
 
   if not libyamlscript_path:
     raise Exception(
-      "Shared library file '%s' not found." % libyamlscript_name)
+      """\
+Shared library file '%s' not found
+Try: curl -sSL yamlscript.org/install | VERSION=%s LIB=1 bash
+See: https://github.com/yaml/yamlscript/wiki/Installing-YAMLScript
+""" % (libyamlscript_name, yamlscript_version))
 
   return libyamlscript_path
 
@@ -92,11 +96,14 @@ class YAMLScript():
     self.isolatethread = ctypes.c_void_p()
 
     # Create a new GraalVM isolate:
-    libyamlscript.graal_create_isolate(
+    rc = libyamlscript.graal_create_isolate(
       None,
       None,
       ctypes.byref(self.isolatethread),
     )
+
+    if rc != 0:
+      raise Exception("Failed to create isolate")
 
   # Compile and eval a YAMLScript string and return the result:
   def load(self, input):
@@ -128,6 +135,6 @@ class YAMLScript():
   # YAMLScript instance destructor:
   def __del__(self):
     # Tear down the isolate thread to free resources:
-    ret = libyamlscript.graal_tear_down_isolate(self.isolatethread)
-    if ret != 0:
-      raise Exception("Failed to tear down isolate.")
+    rc = libyamlscript.graal_tear_down_isolate(self.isolatethread)
+    if rc != 0:
+      raise Exception("Failed to tear down isolate")

--- a/raku/lib/YAMLScript.rakumod
+++ b/raku/lib/YAMLScript.rakumod
@@ -1,3 +1,6 @@
+# Copyright 2023-2024 Ingy dot Net
+# This code is licensed under MIT license (See License for details)
+
 unit class YAMLScript;
 
 use NativeCall;

--- a/www/src/index.md
+++ b/www/src/index.md
@@ -181,7 +181,7 @@ Test your new `ys` installation by running:
 ```text
 $ ys --help
 
-ys - The YAMLScript (YS) Command Line Tool
+ys - The YAMLScript (YS) Command Line Tool - v0.1.47
 
 Usage: ys [<option...>] [<file>]
 

--- a/www/src/posts/advent-2023/dec-05.md
+++ b/www/src/posts/advent-2023/dec-05.md
@@ -108,7 +108,7 @@ $ ys --help
 It should display:
 
 ```text
-ys - The YAMLScript (YS) Command Line Tool
+ys - The YAMLScript (YS) Command Line Tool - v0.1.47
 
 Usage: ys [<option...>] [<file>]
 

--- a/www/src/posts/advent-2023/dec-07.md
+++ b/www/src/posts/advent-2023/dec-07.md
@@ -32,29 +32,44 @@ The best first command to run is `ys --help`:
 
 ```bash
 $ ys --help
-ys - The YAMLScript (YS) Command Line Tool
 
-Usage: ys [options] [file]
+ys - The YAMLScript (YS) Command Line Tool - v0.1.47
+
+Usage: ys [<option...>] [<file>]
 
 Options:
-  -r, --run                Compile and evaluate a YAMLScript file (default)
-  -l, --load               Output the evaluated YAMLScript value
-  -c, --compile            Compile YAMLScript to Clojure
+
+      --run                Run a YAMLScript program file (default)
+  -l, --load               Output (compact) JSON of YAMLScript evaluation
   -e, --eval YSEXPR        Evaluate a YAMLScript expression
-  -C, --clj                Treat input as Clojure code
+                           multiple -e values joined by newline
 
-  -m, --mode MODE          Add a mode tag: code, data, or bare (only for --eval/-e)
+  -c, --compile            Compile YAMLScript to Clojure
+  -b, --binary             Compile to a native binary executable
+
   -p, --print              Print the result of --run in code mode
+  -o, --output FILE        Output file for --load, --compile or --binary
 
-  -o, --output             Output file for --load or --compile
-  -t, --to FORMAT          Output format for --load
-
-  -J, --json               Output JSON for --load
+  -T, --to FORMAT          Output format for --load:
+                             json, yaml, edn
+  -J, --json               Output (pretty) JSON for --load
   -Y, --yaml               Output YAML for --load
   -E, --edn                Output EDN for --load
 
-  -X, --debug              Debug mode: print full stack trace for errors
-  -x, --debug-stage STAGE  Display the result of stage(s)
+  -m, --mode MODE          Add a mode tag: code, data, or bare (for -e)
+  -C, --clojure            Treat input as Clojure code
+
+  -d                       Debug all compilation stages
+  -D, --debug-stage STAGE  Debug a specific compilation stage:
+                             parse, compose, resolve, build,
+                             transform, construct, print
+                           can be used multiple times
+  -S, --stack-trace        Print full stack trace for errors
+  -x, --xtrace             Print each expression before evaluation
+
+      --install            Install the libyamlscript shared library
+      --upgrade            Upgrade both ys and libyamlscript
+
       --version            Print version and exit
   -h, --help               Print this help and exit
 ```

--- a/ys/src/yamlscript/cli.clj
+++ b/ys/src/yamlscript/cli.clj
@@ -97,6 +97,8 @@
     "Output YAML for --load"]
    ["-E" "--edn"
     "Output EDN for --load"]
+   ["-O" "--ordered"
+    "Mappings preserve key order"]
 
    ["-m" "--mode MODE"
     "Add a mode tag: code, data, or bare (for -e)"
@@ -278,7 +280,6 @@ Options:
   (if (:clojure opts)
     code
     (try
-      (reset! common/opts opts)
       (if (empty? (:debug-stage opts))
         (compiler/compile code)
         (do
@@ -449,7 +450,12 @@ Options:
         opts (if (:edn opts) (assoc opts :to "edn") opts)
         opts (if (:to opts) (assoc opts :load true) opts)
         opts (if (and (not (:mode opts)) (seq (:eval opts)))
-               (assoc opts :mode "code") opts)]
+               (assoc opts :mode "code") opts)
+        opts (if (System/getenv "YS_ORDERED")
+               (assoc opts :ordered true) opts)]
+
+    (reset! common/opts opts)
+
     (cond
       error (do-error [(str "Error: " error)])
       (seq errs) (do-error errs)


### PR DESCRIPTION
AFAIK clojure does not support preserving key order in its standard hash type. This is awkward for cases where one needs to preserve key order in output YAML -- can that be made possible?