### PR TITLE
Fixed program.ys loop program in Control Flow documentation

### DIFF
--- a/doc/control.md
+++ b/doc/control.md
@@ -41,8 +41,8 @@ cast to numbers if they look like numbers.
 ```yaml
 !yamlscript/v0
 
-defn main(word='Hello!' times=3)
-  for i (1 .. times):
+defn main(word='Hello!' times=3):
+  each i (1 .. times):
     say: "$i) $word"
 ```
 


### PR DESCRIPTION
I'm starting to experiment with yamlscript, but I ran into a little wall. The `program.ys` in https://yamlscript.org/doc/control/ has a couple of bugs. The first is easy, the main function doesn't have a colon delimiter at the end of the line.

The second one is that nothing is output when using the `for` function. I believe it needs to be `each`. 