### PR TITLE
core: Fix GitHub syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ys linguist-language=yaml


### PR DESCRIPTION
Force GitHub to highlight `*.ys` files as YAML.