### PR TITLE
Fix brew-update util, and add CI

### DIFF
--- a/.github/workflows/brew-update.yaml
+++ b/.github/workflows/brew-update.yaml
@@ -1,0 +1,50 @@
+name: Update Homebrew Formulae
+on:
+  release:
+    types: [released]
+
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+    - .github/workflows/brew-update.yaml
+
+jobs:
+  Update:
+    runs-on: macos-latest
+    steps:
+    - name: Tap
+      run: |
+        brew tap ${{ github.repository_owner }}/yamlscript
+        brew install ys
+
+    - name: Livecheck
+      id:   livecheck
+      env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+      run: |
+        brew livecheck --newer-only --quiet --json ys |
+        jq --raw-output '"version=\(.[].version.latest)"' >> $GITHUB_OUTPUT
+
+    - name: Checkout
+      if: steps.livecheck.outputs.version != ''
+      uses: actions/checkout@v4
+
+    - name: Configure Git
+      if: steps.livecheck.outputs.version != ''
+      run: |
+        git config --global user.name  ${{ github.repository_owner }}
+        git config --global user.email ${{ github.event.pusher.email }}
+
+    - name: Bump Version
+      if: steps.livecheck.outputs.version != ''
+      env:
+        version:  ${{ steps.livecheck.outputs.version }}
+        GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      run: |
+        util/brew-update $version
+        cd homebrew-yamlscript
+        gh auth setup-git
+        git add --all
+        git commit --message "Update $version"
+        git push

--- a/Makefile
+++ b/Makefile
@@ -193,19 +193,6 @@ ifndef d
 endif
 
 release-yamlscript: $(BUILD_BIN_YS)
-ifneq (main, $(shell git rev-parse --abbrev-ref HEAD))
-	$(error You must be on the 'main' branch to release)
-endif
-ifndef o
-	$(error Please set Makefile variable o=#.#.#)
-endif
-ifndef n
-	$(error Please set Makefile variable n=#.#.#)
-endif
-	@[[ $$YS_GH_USER ]] || { \
-	  echo 'Please export YS_GH_USER'; exit 1; }
-	@[[ $$YS_GH_TOKEN ]] || { \
-	  echo 'Please export YS_GH_TOKEN'; exit 1; }
 	(time $< $(ROOT)/util/release-yamlscript $o $n $s) 2>&1 | \
 	  tee -a $(RELEASE_LOG)
 

--- a/util/brew-update
+++ b/util/brew-update
@@ -9,11 +9,13 @@ defn main(version):
   download-releases: version
   update-brew: version
 
+os =: System/getProperty('os.name')
+
 defn sha256sum(file):
-  os =: System/getProperty('os.name')
-  cond:
-    os =~ /Mac\s?OS/: sh("shasum -a 256 $file")
-    else: sh("sha256sum $file")
+  sh:
+    if os =~ /Mac\s?OS/:
+      then: "shasum -a 256 $file"
+      else: "sha256sum $file"
 
 defn update-brew(version):
   releases =: releases(version)
@@ -58,9 +60,7 @@ defn download-releases(version):
       when-not fs-e(file):
         say: "Downloading $file"
         url =: "$releases-url/download/$version/$file"
-        res =: sh("curl --silent --location $url --output $file")
-        when res.exit:N.?:
-          die: "Download of '$url' failed:\n$(res.err)"
+        spit file: curl(url)
 
 defn releases(version)::
   LIN_ARM:: "ys-${version}-linux-aarch64.tar.xz"

--- a/util/brew-update
+++ b/util/brew-update
@@ -8,6 +8,12 @@ defn main(version):
   download-releases: version
   update-brew: version
 
+defn sha256sum(file):
+  os =: System/getProperty("os.name")
+  cond:
+    os =~ /Mac\s?OS/: sh("shasum -a 256 $file")
+    else: sh("sha256sum $file")
+
 defn update-brew(version):
   releases =: releases(version)
 
@@ -22,7 +28,7 @@ defn update-brew(version):
   text =:
     reduce-kv _ text releases:
       fn(text key file):
-        sha256 =: sh("sha256sum $file").out:words.0
+        sha256 =: sha256sum(file).out:words.0
         text: .replace(key sha256)
 
   say: "Updating homebrew-yamlscript/ys.rb"
@@ -51,7 +57,7 @@ defn download-releases(version):
       when-not fs-e(file):
         say: "Downloading $file"
         url =: "$releases-url/download/$version/$file"
-        res =: sh("wget -q $url")
+        res =: sh("curl --silent --location $url --output $file")
         when res.exit:N.?:
           die: "Download of '$url' failed:\n$(res.err)"
 

--- a/util/brew-update
+++ b/util/brew-update
@@ -1,7 +1,8 @@
 #!/usr/bin/env ys-0
 
 releases-url =: 'https://github.com/yaml/yamlscript/releases'
-brew-url =: 'git@github.com:yaml/homebrew-yamlscript'
+repo =: ENV.GITHUB_REPOSITORY_OWNER || 'yaml'
+brew-url =: "https://github.com/$repo/homebrew-yamlscript"
 
 defn main(version):
   check-version: version
@@ -9,7 +10,7 @@ defn main(version):
   update-brew: version
 
 defn sha256sum(file):
-  os =: System/getProperty("os.name")
+  os =: System/getProperty('os.name')
   cond:
     os =~ /Mac\s?OS/: sh("shasum -a 256 $file")
     else: sh("sha256sum $file")

--- a/util/markys
+++ b/util/markys
@@ -1,6 +1,6 @@
 #!/usr/bin/env ys-0
 
-input-dir =: A(nil)
+input-dir =: atom(nil)
 
 DNE =: "<!-- DO NOT EDIT — THIS FILE WAS GENERATED -->\n\n"
 

--- a/util/release-yamlscript
+++ b/util/release-yamlscript
@@ -214,8 +214,6 @@ defn step-8(ctx):
 defn step-9(ctx):
   o: "Step 9) Run 'make release-assets'"
 
-  prompt: 'Press Enter when ready to continue.'
-
   run:: make test-core test-ys
 
   run:: make release-assets


### PR DESCRIPTION
- Fixes [util/brew-update](https://github.com/yaml/yamlscript/blob/main/util/brew-update) to work cross-platform
- Add CI workflow

#### YAMLScript
Ideally, the `util/brew-update` script would be replaced with `brew`[`bump-formula-pr`](https://docs.brew.sh/Manpage#bump-formula-pr-options-formula), but this doesn't currently seem to work properly with formulae containing multiple `url`s and `sha256`sums. Fixing that will be yet another PR, over on Homebrew…

#### CI
The workflow will run on every release, and uses `brew`[`livecheck`](https://docs.brew.sh/Brew-Livecheck) to only update if the release SemVer tag is newer than the latest [formula](https://github.com/yaml/homebrew-yamlscript/blob/main/ys.rb). You can preview the CI in _action_ on my [fork](https://github.com/danielbayley/yamlscript/actions)…
The workflow just requires an organisation [`ACCESS_TOKEN`](https://github.com/yaml/yamlscript/settings/secrets/actions/new)…

See also [#205](https://github.com/yaml/homebrew-yamlscript/pull/3) and https://github.com/yaml/yamlscript/issues/197#issuecomment-2557378497.