### PR TITLE
Fix sidebar keyboard navigation

### DIFF
--- a/www/mkdocs.ys
+++ b/www/mkdocs.ys
@@ -60,6 +60,8 @@ theme:: load('config/theme.yaml')
 # https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/
 extra_css:
 - css/theme.css
+extra_javascript:
+- javascript/extra.js
 
 # See theme/main.html for Google Tag Manager setup code
 extra:

--- a/www/src/css/theme.css
+++ b/www/src/css/theme.css
@@ -153,3 +153,48 @@ h1.empty {
   -webkit-mask-image: var(--md-admonition-icon--rss);
           mask-image: var(--md-admonition-icon--rss);
 }
+
+
+/* when sidebar is not open, hide it to make it unfocusable */
+.md-toggle[data-md-toggle='drawer']:not(:checked)
+  ~ .md-container
+  .md-nav[data-md-level='0'],
+/* when the nested menus in the sidebar are not open, hide them
+   to make them unfocusable */
+.md-container
+  .md-nav[data-md-level='0']
+  input.md-toggle[type='checkbox']:not(:checked)
+  ~ nav {
+  visibility: hidden;
+}
+
+/* when a nested menu is open in the sidebar, hide the sidebar content 
+   to make it unfocusable */
+.md-toggle[data-md-toggle='drawer']:checked
+  ~ .md-container
+  .md-nav[data-md-level='0']:has(input:checked)
+  > ul
+  > li
+  > .md-nav__link,
+.md-toggle[data-md-toggle='drawer']:checked
+  ~ .md-container
+  .md-nav[data-md-level='0']:has(input:checked)
+  > *
+  > a,
+/* when a nested menu is open in the nested menus, hide its content
+   to make it unfocusable */
+.md-container
+  .md-nav[data-md-level='0']
+  input.md-toggle[type='checkbox']:checked
+  ~ nav:has(input:checked)
+  > ul
+  > li
+  > .md-nav__link,
+.md-container
+  .md-nav[data-md-level='0']
+  input.md-toggle[type='checkbox']:checked
+  ~ nav:has(input:checked)
+  > *
+  > a {
+  visibility: hidden;
+}

--- a/www/src/javascript/extra.js
+++ b/www/src/javascript/extra.js
@@ -23,4 +23,10 @@ document$.subscribe(function () {
       }
     });
   });
+
+  // make interactive elements in the sidebar focusable
+  const selectors = ["nav .md-nav__title", "nav .md-nav__link"];
+  Array.from(document.querySelectorAll(selectors.join(","))).forEach((el) => {
+    el.setAttribute("tabindex", 0);
+  });
 });

--- a/www/src/javascript/extra.js
+++ b/www/src/javascript/extra.js
@@ -1,0 +1,26 @@
+document$.subscribe(function () {
+  const sidebarControl = document.querySelector(
+    ".md-toggle[data-md-toggle='drawer']"
+  );
+
+  // Disable interaction with header, content, and footer when the sidebar
+  // drawer is open.
+  sidebarControl.addEventListener("change", (e) => {
+    const selectors = [
+      "header",
+      ".md-content",
+      ".md-sidebar[data-md-type='toc']",
+      "footer",
+    ];
+    const isChecked = e.target.checked;
+    Array.from(document.querySelectorAll(selectors.join(","))).forEach((el) => {
+      if (el) {
+        if (isChecked) {
+          el.setAttribute("inert", true);
+        } else {
+          el.removeAttribute("inert");
+        }
+      }
+    });
+  });
+});

--- a/www/src/javascript/extra.js
+++ b/www/src/javascript/extra.js
@@ -24,6 +24,17 @@ document$.subscribe(function () {
     });
   });
 
+  // close the sidebar when ESC key is pressed
+  document.addEventListener("keydown", (e) => {
+    const isEscape = e.key === "Escape" || e.key === "Esc";
+    if (!isEscape || !sidebarControl.checked) {
+      return;
+    }
+
+    document.querySelector(".md-overlay[for='__drawer']").click();
+    document.querySelector(".md-header__button[for='__drawer']").focus();
+  });
+
   // make interactive elements in the sidebar focusable
   const selectors = ["nav .md-nav__title", "nav .md-nav__link"];
   Array.from(document.querySelectorAll(selectors.join(","))).forEach((el) => {

--- a/www/theme/partials/header.html
+++ b/www/theme/partials/header.html
@@ -9,7 +9,7 @@
     <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
     </a>
-    <label class="md-header__button md-icon" for="__drawer">
+    <label class="md-header__button md-icon" for="__drawer" tabindex="0">
       {% set icon = config.theme.icon.menu or "material/menu" %}
       {% include ".icons/" ~ icon ~ ".svg" %}
     </label>


### PR DESCRIPTION
## Description

This PR improves keyboard accessibility on [yamlscript.org](https://yamlscript.org/) by addressing several issues:
- The sidebar toggle button was not focusable by keyboard.
- Sidebar menu items were focusable even when the sidebar was closed.
- Some elements had missing or incorrect `tabindex` attributes, making them unfocusable.

![yamlscript-tabindex2](https://github.com/user-attachments/assets/9ff8379f-55c7-4130-803f-c5ae675b86df)
![yamlscript-tabindex](https://github.com/user-attachments/assets/8d036fe0-1df0-4298-a5ec-45efe52c8ada)

Currently `mkdocs-material` seems to be on [feature freeze](https://github.com/squidfunk/mkdocs-material/discussions/4102#discussioncomment-13173967), thus making changes here. The update aims to make sidebar navigation accessible via keyboard, following the [WAI-ARIA Menubar Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/) as much as possible. The focus is on meeting [WCAG 2.1: Keyboard Accessible](https://www.w3.org/WAI/WCAG21/Understanding/keyboard-accessible) requirements. Additional improvements may follow in future PRs

## Changes:
- Added `tabindex` to the sidebar toggle button so it can be focused with the keyboard.
- Toggled the `inert` attribute on sidebar open/close to prevent focus on hidden sidebar items.
- Set correct `tabindex` values for all interactive elements.
- Pressing `ESC` now closes the sidebar and returns focus to the sidebar toggle button.
- When a nested menu (like `Using YS`) is open, sibling menus are hidden and not focusable.

---

## Local Testing

- Home page:  

  https://github.com/user-attachments/assets/461e6c80-92a8-4bc2-88ed-259a64a62fb1

- Documentation page:  

  https://github.com/user-attachments/assets/a1303103-dc35-4e4e-b566-ca5238179b86
