### PR TITLE
doc/ and blog/ typo fixes

### DIFF
--- a/blog/2023-12-20.md
+++ b/blog/2023-12-20.md
@@ -186,7 +186,7 @@ Isn't that pretty cool?
 You can native compile a `-e` one liner!
 
 Since the output file needs a name, `ys` uses `./EVAL` when you use `-e`.
-You can use the `-o` option to to name the file explicitly.
+You can use the `-o` option to name the file explicitly.
 Otherwise it defaults to the name of the YS file with the `.ys` extension
 removed.
 

--- a/blog/2024-11-05.md
+++ b/blog/2024-11-05.md
@@ -101,7 +101,7 @@ the Exercism set of languages:
 * [Rot-13](
   https://gist.github.com/ingydotnet/c39752822b2197191e320e46ddde025c)
 
-As you can see, YS programs turn out to to be very clean, simple and
+As you can see, YS programs turn out to be very clean, simple and
 easy to read.
 
 If you are going to enhance your YAML files with functional logic, it's

--- a/blog/2025-03-10.md
+++ b/blog/2025-03-10.md
@@ -5,7 +5,7 @@ draft: false
 authors: [ingydotnet]
 categories: [General]
 edit: blog/2025-03-10.md
-talk: 0
+comments: true
 ---
 
 Greetings! And welcome back to [YAMLScript](https://yamlscript.org) in 2025!

--- a/blog/2025-03-24.md
+++ b/blog/2025-03-24.md
@@ -1,0 +1,376 @@
+---
+title: Run a YAML File with Bash!
+date: 2025-03-24
+draft: false
+authors: [ingydotnet]
+categories: [General]
+edit: blog/2025-03-24.md
+talk: 0
+---
+
+Wait, what?!!?
+
+***Run*** a YAML file?
+
+And with Bash?
+
+How is that possible?
+
+<!-- more -->
+
+
+## Step 0
+
+Let's run this simple YAML `file.yaml`:
+
+```yaml
+name: Fido
+age: 3
+dog years: age * 7
+```
+
+When we run this file, we'd like to see this JSON output:
+
+```json
+{
+  "name": "Fido",
+  "age": 3,
+  "dog years": 21
+}
+```
+
+```bash
+$ bash file.yaml
+file.yaml: line 1: name:: command not found
+file.yaml: line 2: age:: command not found
+file.yaml: line 3: dog: command not found
+```
+
+Well that didn't work...
+
+Let's not give up yet.
+
+
+
+## Step 1
+
+Let's forget about Bash for a moment and just load the YAML file with [YS](
+https://yamlscript.org):
+
+```bash
+$ ys -J file.yaml
+{"name":"Fido", "age":3, "dog years":"age * 7"}
+```
+
+Close, but look at the `dog years` value. It's just a string.
+
+We need to tell YS to evaluate the expression `age * 7` as a math expression.
+
+YS won't do any evaluation unless we tell it to with the `!YS-v0:` tag.
+Then we need to tell YS that just the `dog years` value should be evaluated.
+We do that with the `::` syntax:
+
+```yaml
+!YS-v0:
+name: Fido
+age: 3
+dog years:: age * 7
+```
+
+Let's run it:
+
+```bash
+$ ys -J file.yaml
+Error: Could not resolve symbol: age
+```
+
+Oh, right. The `age` symbol is not defined here.
+Luckily we can define it inline:
+
+```yaml
+!YS-v0:
+name: Fido
+age =: 3
+age:: age
+dog years:: age * 7
+```
+
+Again:
+
+```bash
+$ ys -J file.yaml
+{"name":"Fido", "age":3, "dog years":21}
+```
+
+Sweet! We have the JSON output we wanted.
+
+Note: We could do the same thing with an anchor and alias:
+
+```yaml
+!YS-v0:
+name: Fido
+age =: &age 3
+dog years:: 7 * *age
+```
+
+
+## Now Back to Bash
+
+OK. But this YAML file is definitely not a Bash script.
+
+But maybe we can make it one?
+
+Let's try this:
+
+```bash
+#!/usr/bin/env ys-0
+source <(echo 'export YS_FORMAT=json' && curl '-s' 'https://getys.org/run') "$@":
+---
+!YS-v0:
+name: Fido
+age: &age 3
+dog years:: 7 * *age
+```
+
+Now:
+
+```bash
+$ bash file.yaml
+{"name":"Fido", "age":3, "dog years":21}
+```
+
+Woah! It worked! We just ran a YAML file with Bash!
+
+But how?
+
+Well I cheated a bit and showed you the second time I ran it.
+The first time I ran it, I got this:
+
+```bash
+$ bash file.yaml
+Installing YS CLI '/tmp/yamlscript-run-ys/bin/ys-0.1.95' now...
+Ctl-C to abort
+See https://yamlscript.org/doc/run-ys for more information.
+
+Installed /tmp/yamlscript-run-ys/bin/ys - version 0.1.95
+--------------------------------------------------------------------------------
+{"name":"Fido", "age":3, "dog years":21}
+```
+
+The first time you run the file, it installs YS under `/tmp` and then runs the
+file with YS.
+The second time you run it, it just runs the file with YS.
+
+
+## The Polyglot Magic
+
+It turns out that the first two lines of the file are both valid Bash and valid
+YS!
+
+The first line is a Bash shebang that invokes YS, but we ran the file with Bash.
+
+Let's change the shebang to call Bash instead:
+
+```bash
+#!/usr/bin/env bash
+source <(echo 'export YS_FORMAT=json' && curl '-s' 'https://getys.org/run') "$@":
+---
+!YS-v0:
+name: Fido
+age: &age 3
+dog years:: 7 * *age
+```
+
+Then let's make the file executable, and run it:
+
+```bash
+$ chmod +x file.yaml
+$ ./file.yaml
+{"name":"Fido", "age":3, "dog years":21}
+```
+
+Works like a charm!
+
+Ok so what about the second line?
+
+For YS, the `source` command is a no-op.
+A function that ignores its arguments and returns nothing.
+
+For Bash, we are sourcing a "process substitution" that curls a tiny script that
+will install a YS binary under `/tmp` and use it to run that file.
+
+We also set the `YS_FORMAT` environment variable to `json`, which tells YS to
+`--load` the file starting in data mode.
+
+!!! note "Update"
+
+    It seems that you can't source a process substitution in Bash 3.2 (the
+    default `/bin/bash` on MacOS).
+    Fortunately, this variation works on all the versions of Bash used on Linux
+    and MacOS:
+
+    ```bash
+    source /dev/stdin <<<"$(echo 'export YS_FORMAT=json' && curl '-s' 'https://getys.org/run')" "$@":
+    ```
+
+??? "How can that be valid YS?"
+
+    Again, this is both valid Bash and valid YS!
+    Here's how YS compiles the `source` line to Clojure code:
+
+    ```
+    $ ys -c -
+    !YS-v0
+    source /dev/stdin <<<"$(echo 'export YS_FORMAT=json' && curl '-s' 'https://getys.org/run')" "$@":
+
+    (source
+    #"dev"
+    stdin
+    <<<
+    (echo "export YS_FORMAT=json" && curl "-s" "https://getys.org/run")
+    "$@")
+    ```
+
+    The YS `source` function ignores its arguments, but those arguments need to
+    be valid YS code.
+    Ironically here `/dev/stdin` compiles as the regex form `/dev/` followed by
+    the symbol `stdin`!
+    Also `<<<` is valid syntax for a YS operator, but currently there is no
+    operator called `<<<` in YS.
+
+
+## But Why?
+
+Ok, neat trick, but how is this useful in the real world?
+
+First off it's a great way to write a YS program for someone who might not have
+YS installed.
+You don't even need to tell them about YS at all.
+
+But for data files there's a more interesting use case.
+
+Say you have a `config.yaml` config file for some service that you'd like to be
+able to use YS for instead of plain YAML.
+If that service already used YS to load its YAML configs then you'd be all set.
+But most services don't. Yet!
+
+What if you could put a `config.ys` file in the same directory as the
+`config.yaml` file and made it executable?
+And what if the `config.ys` file wrote its output to the `config.yaml` file when
+it was run?
+As long as you could set things up to make sure the `config.ys` file was run
+whenever it (or one of its dependencies) changed, you'd have a generated
+`config.yaml` file that would do everything you wanted it to do.
+
+Let's try it out. We'll make a `config.ys` file that loads an `other.yaml` file
+and uses environment variables to set some values:
+
+```yaml
+!YS-v0:
+name: My Thing
+stuff:: load('other.yaml').stuff
+:when ENV.DEBUG.?::
+  environment:: ENV
+```
+
+And an `other.yaml` file:
+
+```yaml
+stuff:
+  some: data
+```
+
+If we load it with YS we get:
+
+```bash
+$ ys -Y config.ys
+name: My thing
+stuff:
+  some: data
+```
+
+This pulled in a _part_ of the `other.yaml` file.
+It also would add a map of all your environment variables if `DEBUG` was set.
+
+Let's add 2 lines to make it write to `config.yaml`:
+```
+!YS-v0:
+name: My thing
+stuff:: load('other.yaml').stuff
+:when ENV.DEBUG.?::
+  environment:: ENV
+
+--- !YS-v0
+write FILE.replace(/\.ys$/ '.yaml'): _:yaml/dump
+```
+
+Now we can run it:
+
+```bash
+$ ys config.ys && cat config.yaml
+name: My thing
+stuff:
+  some: data
+```
+
+Perfect! Since YS evaluates to the last document in a multi-document file, we
+get what we want by running it.
+
+The only remaining problem is that we need to have `ys` installed to run this...
+
+Or do we?
+
+Let's try it with Bash:
+
+```bash
+#!/usr/bin/env bash
+source <(curl '-s' 'https://getys.org/run') "$@":
+--- !YS-v0:
+
+name: My thing
+stuff:: load('other.yaml').stuff
+:when ENV.DEBUG.?::
+  environment:: ENV
+
+--- !YS-v0
+write FILE.replace(/\.ys$/ '.yaml'): _:yaml/dump
+```
+
+Now:
+
+```bash
+$ chmod +x config.ys
+$ ./config.ys && cat config.yaml
+name: My thing
+stuff:
+  some: data
+```
+
+Voila! We just replaced a `config.yaml` file with a `config.ys` file for any
+YAML configured service.
+
+!!! note "A More Solid Approach"
+
+    The strategy for using YS files to generate YAML files is solid.
+    But you probably don't want to actually run them (with Bash or YS).
+
+    A better way is to simply configure your pipeline to install YS and then run
+    `ys -Y config.ys > config.yaml` at the appropriate time.
+
+
+## Conclusion
+
+I hope you've enjoyed this little journey into the world YS, YAML, and Bash.
+
+Hopefully it gives you some interesting ideas for how to use YS in your own
+projects.
+
+Please let us know if you come up with any super cool uses for this technique.
+
+Happy YAMLing!
+
+
+PS [Ingy](/ingydotnet) (that's me!) will be at [KubeCon in London](
+https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/) next week.
+
+Let's talk about YS, [HelmYS](/helmys), or whatever you'd like!

--- a/blog/2025-06-01.md
+++ b/blog/2025-06-01.md
@@ -1,0 +1,127 @@
+---
+title: The Summer of YS
+date: 2025-06-01
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-01.md
+comments: true
+---
+
+Today starts a 3 month long, daily summertime journey into the intricacies of
+YAML and the wisdom of YS!
+Put on your favorite pair of coding sunglasses, grab a refreshing config drink,
+and let's get started!
+
+Back in March I promised to start writing more often about all the ways that YS
+can help you out day-to-day with your YAML interactions.
+When I last posted here it was barely Spring and now Spring is turning into
+Summer.
+
+Seasonal turning points be damned, I think of Summer as June, July, and August.
+In other words...
+
+**It's Summer dammit!**
+
+Let's declare this Summer, **The Summer of YS**!
+
+<!-- more -->
+
+
+## Summertime... and the YAML's Easy
+
+Wanna learn 92 cool things about YAML and YS this Summer?
+That's one per day, for 3 months!
+
+I've attempted some crazy things in my days (with both success and failure), and
+this feels pretty crazy, but I'm gonna give it a shot.
+
+I'll post one (mostly short) blog post here each day until the end of August
+(mostly) about YAML and/or YS.
+
+
+## Today's Handy Tip
+
+I'm not gonna just announce this fiasco and leave you hanging until tomorrow for
+your first tip.
+Let's get into it.
+
+----
+
+I like to keep the lines of most of my text files (including the markdown of
+this very blog post) at 80 characters or less.
+You might have a different preference (I still love you) but that's how I roll.
+
+YAML is pretty good at letting you wrap long strings at places of your choosing.
+
+```
+phrase1: The quick brown fox jumped up and down
+  and all around while the lazy dog just lay
+  all day with nothing to say.
+phrase2:
+  The quick brown fox jumped up and down and all
+  around while the lazy dog just lay all day
+  with nothing to say.
+phrase3: "The quick brown fox jumped up and down and all around while the lazy dog just lay all day with nothing to say."
+phrase4: "\
+  The quick brown fox jumped up and down and all around
+  while the lazy dog just lay all day with nothing to say."
+phrase5: >
+  The quick brown fox jumped up and down and all around
+  while the lazy dog just lay all day with nothing to say.
+```
+
+These values are all the same.
+They just use different YAML syntax to wrap the string.
+YAML generally wraps multiline strings, by collapsing a newline (and leading
+whitespace) into a single space.
+
+But what if you have a long string with no whitespace at all?
+This is a common problem when you have long URLs in your YAML files.
+
+There is a way to split these long strings in YAML, and it only works with
+double quoted scalars.
+
+```yaml
+loong: https://gist.githubusercontent.com/ingydotnet/2e5a79b0b29e548a39a90dba10846042/raw/c05feff49521caf004b5656dcb0e94715a30fffd/stdin
+short: "https://gist.githubusercontent.com/\
+        ingydotnet/\
+        2e5a79b0b29e548a39a90dba10846042/\
+        raw/\
+        c05feff49521caf004b5656dcb0e94715a30fffd/\
+        stdin"
+```
+
+Just use a backslash at the end of each line in a double quoted scalar and it
+will collapse without a space.
+
+**Are these 2 values exactly the same?**
+
+I don't have a magic 8-ball, so let's use (_wise ol'_) YS to find out!
+
+```
+$ ys -pe '_.short == _.loong' - <<'...'
+loong: https://gist.githubusercontent.com/ingydotnet/2e5a79b0b29e548a39a90dba10846042/raw/c05feff49521caf004b5656dcb0e94715a30fffd/stdin
+short: "https://gist.githubusercontent.com/\
+        ingydotnet/\
+        2e5a79b0b29e548a39a90dba10846042/\
+        raw/\
+        c05feff49521caf004b5656dcb0e94715a30fffd/\
+        stdin"
+...
+true
+```
+
+!!! note "YS Replies:"
+
+    ## _**It is decidedly so!**_
+
+
+## See You Tomorrow!
+
+One down, 91 to go!
+
+How hard can this be?
+
+Tomorrow I think I'll show you how to use variables in YAML.
+You always wanted to know, right?

--- a/blog/2025-06-02.md
+++ b/blog/2025-06-02.md
@@ -1,0 +1,152 @@
+---
+title: YAML Variables
+date: 2025-06-02
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-02.md
+comments: true
+---
+
+YAML itself isn't a functional programming language, but advanced users are
+probably aware of YAML's anchors, aliases and the merge key.
+
+The merge key is YAML's one functional thing, and it's actually not even part of
+the [YAML 1.2 spec](https://yaml.org/spec/1.2.2/).
+However, people find it useful and many YAML implementations (including YS)
+support it.
+
+The merge key (`<<`) is a special key that allows you to merge the contents of
+one mapping into another.
+
+Today we'll explore the merge key a bit and show how **variables** can make it
+nicer to use.
+
+<!-- more -->
+
+
+## The Merge Key
+
+Consider the following YAML file:
+
+```yaml
+# shoes.yaml
+- &defaults
+  size: 10
+  color: blue
+
+- name: sneaker
+  <<: *defaults
+  color: red
+
+- name: boot
+  <<: *defaults
+  color: black
+
+- name: sandal
+  size: 8
+  <<: *defaults
+```
+
+We can convert it to JSON with YS:
+
+```bash
+$ ys -J shoes.yaml
+[{"size":10, "color":"blue"},
+ {"name":"sneaker", "color":"red", "size":10},
+ {"name":"boot", "color":"black", "size":10},
+ {"name":"sandal", "size":8, "color":"blue"}]
+```
+
+Here we define a mapping of default values with an anchor name of `&defaults`,
+and then we merge it into each of the other mappings using the merge key `<<`
+and a value alias of `*defaults`.
+
+This works out ok but it has a problem.
+Can you see it?
+
+We've defined a sequence of 3 shoe mappings, but we have 4 things in the
+sequence.
+The defaults mapping itself is a (probably unwanted) part of the sequence.
+
+The problem with this common scenario is that there is no way in YAML itself to
+declare the thing that is to be merged, but not have it be part of the result.
+
+
+## YS Variables to the Rescue
+
+There are so many things I could show you about YS using this example, but today
+I'll just use it to introduce you to YS variables.
+(Remember, I have at least 90 more posts to write this summer!)
+
+Let's change the YAML file to use a variable to store the default values.
+Here's one way to do that:
+
+```yaml
+!YS-v0
+
+defaults =::
+  size: 10
+  color: blue
+
+=>::
+- name: sneaker
+  <<:: defaults
+  color: red
+
+- name: boot
+  <<:: defaults
+  color: black
+
+- name: sandal
+  size: 8
+  <<:: defaults
+```
+
+Let's load that and see what we get:
+
+```bash
+$ ys -J shoes2.yaml
+[{"name":"sneaker", "color":"red", "size":10},
+ {"name":"boot", "color":"black", "size":10},
+ {"name":"sandal", "size":8, "color":"blue"}]
+```
+
+That's more like it!
+
+
+## YS Syntax Review
+
+Let's take a moment to review the YS syntax we used here.
+
+!!! note
+
+    I'll probably say it a lot this summer, but I'll say it now:
+
+    YAML with YS is always 100% valid YAML.
+    It literally has to be.
+    That topic should be an interesting post.
+
+    Maybe mid-July...
+
+1. We start with `!YS-v0` to indicate that we want this file to be able to use
+   code features like variables.
+2. We define a variable called `defaults` with a value of our default values.
+3. We use `::` instead of `:` when we need to switch from code mode to data
+   mode (or vice versa).
+   More on that in a future post.
+4. The `::` after the merge key means that the value word `defaults` is a
+   variable (not the string `"defaults"`).
+5. We use the dummy key `=>` to evaluate everything as a sequence rather than a
+   mapping (because the YAML document was already a mapping due to the variable
+   assignment).
+
+## See You Tomorrow!
+
+There is sooo much more that I could tell you about YAML and YS just in the
+context of this little example.
+But I'm going to pace myself and take it slow.
+
+After all, it's Summertime. :sunglasses:
+
+See ya tomorrow!

--- a/blog/2025-06-03.md
+++ b/blog/2025-06-03.md
@@ -1,0 +1,185 @@
+---
+title: YS YAML Documents
+date: 2025-06-03
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-03.md
+comments: true
+---
+
+YAML files (aka YAML streams) can contain multiple "documents".
+
+A YAML document is a top level mapping or sequence "node".
+Most YAML files contain a single document, but YAML files can contain multiple
+(or zero!) documents.
+New documents are started with a line of three dashes: `---`.
+
+YS can put these documents to all kinds of good use.
+
+When you "load" a YAML file with YS, the result is the evaluation of the final
+document (by default).
+But since YS is functional, it can access any of the other documents.
+
+Let's continue with [yesterday's](/blog/2025-06-02/yaml-variables/) shoes
+example.
+
+<!-- more -->
+
+
+## Anchors Up
+
+One of the (unfortunate, imho) rules of YAML is that you can't use aliases to
+reference anchored nodes in other documents.
+
+```bash
+$ ys -Y - <<<'
+--- &number 7
+---
+lucky: *number
+'
+Error: Anchor not found: &number
+```
+
+Since YS follows the the rules of the YAML 1.2 spec, it can't do what we want
+here.
+This is just a plain old YAML "stream" (complete YAML file or string).
+
+What happens if we supercharge things with the YS `!YS-v0` tag?
+
+```bash
+$ ys -Y - <<<'
+--- &number 7
+--- !YS-v0:
+lucky: *number
+'
+lucky: 7
+```
+
+Nice!
+
+Enabling YS for a document allowed us to play by YS rules and access (alias)
+anchored nodes in other documents.
+That's handy.
+
+But wait.
+Why did we use `!YS-v0:` instead of just `!YS-v0`?
+
+* `!YS-v0` - This document is YS code. (start in code mode)
+* `!YS-v0:` - This doc is data, but YS magics are enabled. (start in data mode)
+* Documents without either are just plain YAML. No YS magics. (bare mode)
+
+We'll talk more about mode setting tags in a future post.
+
+
+## New shoes!
+
+Let's take what we just learned and refactor our shoes example.
+
+```yaml
+# shoes.yaml
+--- &defaults
+size: 10
+color: blue
+
+--- !YS-v0:
+- name: sneaker
+  <<: *defaults
+  color: red
+
+- name: boot
+  <<: *defaults
+  color: black
+
+- name: sandal
+  size: 8
+  <<: *defaults
+```
+
+And now load it:
+
+```bash
+$ ys -J shoes.yaml
+[{"name":"sneaker", "color":"red", "size":10},
+ {"name":"boot", "color":"black", "size":10},
+ {"name":"sandal", "size":8, "color":"blue"}]
+```
+
+That's cleaner than [yesterday's](/blog/2025-06-02/yaml-variables/) examples.
+
+
+## Docs and Variables
+
+Anchors are OK, but they're a bit noisy compared to variables.
+
+For fun, let's try using both with multiple documents.
+
+```yaml
+---
+- &size 10
+- &color blue
+
+--- !YS-v0
+defaults =::
+  color: *color
+  size: *size
+
+--- !YS-v0:
+- name: sneaker
+  <<:: defaults
+  color: red
+
+- name: boot
+  <<:: defaults
+  color: black
+
+- name: sandal
+  size: 8
+  <<:: defaults
+```
+
+Then:
+
+```bash
+$ ys -J shoes.yaml
+[{"name":"sneaker", "color":"red", "size":10},
+ {"name":"boot", "color":"black", "size":10},
+ {"name":"sandal", "size":8, "color":"blue"}]
+```
+
+This example is somewhat contrived, but it shows off most everything we've
+talked about so today.
+
+We have 3 documents here.
+
+In the first document, instead of anchoring the defaults mapping, we anchored
+the size and color values.
+This document had no starting tag, so it's plain old YAML (bare mode).
+
+Next, we used a code mode document to define a variable named `defaults` which
+contains the size and color values.
+It got the values by aliasing the size and color values from a different
+document.
+Note the use of `=::` (extra colon) to switch to data mode to define the
+mapping.
+
+Finally we have our data mode document that produces the mapping we want.
+It references the `defaults` variable we defined in the previous document by
+using `::` to switch over to code mode when needed.
+
+Pretty cool.
+
+
+## Walking in these Shoes
+
+There's a few more interesting topics we can get into using the shoes example.
+
+If this is all seeming too simple, believe me, we'll be getting into some deep
+waters this summer.
+Patience, young hacker.
+
+A YS guy once said:
+
+> "The journey of 92 days begins with a few steps in these shoes."
+
+See you tomorrow!

--- a/blog/2025-06-04.md
+++ b/blog/2025-06-04.md
@@ -1,0 +1,191 @@
+---
+title: Load and Compose your YAML Files
+date: 2025-06-04
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-04.md
+comments: true
+---
+
+Probably the biggest problem people have with YAML is that everything has to be
+in one file.
+Things start off nice and clean, but as requirements grow, so do your files!
+
+What if you could compose your YAML documents like you compose your code?
+Lots of small, single-purpose, possibly reusable files that you can load and
+compose together into the thing you need?
+
+That's what YS is all about.
+As you know, YS is a functional language, and it has quite a few ways to load
+data (and code too, since Code is Data™!) from external sources.
+
+Today we'll be looking at how to load things from disk files, including:
+
+* Other YS files
+* YAML files (YAML is YS)
+* JSON files (JSON is YAML)
+
+You can also load things from CSV/TSV files, shell commands, databases, APIs,
+environment variables, and the web, but those are topics for another day.
+
+<!-- more -->
+
+
+## Loading YAML Files
+
+YS has a standard library function called `load` that can load YS files.
+
+Since YAML is YS, you can load YAML files with `load`.
+And since JSON is YAML, you can also load JSON files with `load`.
+
+Let's try on some new shoes!
+
+We'll put each shoe in its own file.
+
+```yaml
+# shoe1.yaml
+name: sneaker
+color: red
+```
+
+```json
+# shoe2.json
+{
+  "name": "boot",
+  "color": "black"
+}
+```
+
+```yaml
+# shoe3.ys
+!YS-v0:
+name: sandal
+size:: 2 * 2 * 2
+```
+
+I got a little cheeky on that third shoe.
+I used a YS expression to calculate the size!
+That's just to show that YS expressions evaluate on load.
+
+Let's load them all together.
+
+```yaml
+# shoes.yaml
+!YS-v0:
+- ! load('shoe1.yaml')
+- ! load('shoe2.json')
+- ! load('shoe3.ys')
+```
+
+Notice the `!` there?
+Remember the `::` mode switcher?
+
+Well `::` is just a nice shorthand for `!`.
+It works great with mapping pairs, but for sequence entries, there's no way to
+use it, so we need to use `!` instead.
+
+```bash
+$ ys -Y shoes.yaml
+- name: sneaker
+  color: red
+- name: boot
+  color: black
+- name: sandal
+  size: 8
+```
+
+It works, but we don't have the defaults in there.
+
+We'll make a defaults file like this:
+
+```yaml
+# defaults.yaml
+size: 10
+color: blue
+```
+
+Now we could use the merge key (`<<`) to add it to the YAML and YS files,
+but that would never work in a JSON file.
+
+Fortunately, YS is a functional language with 100s of functions.
+Surely it has a `merge` function!
+
+```yaml
+# shoes.yaml
+!YS-v0:
+- ! merge(load('defaults.yaml'), load('shoe1.yaml'))
+- ! merge(load('defaults.yaml'), load('shoe2.json'))
+- ! merge(load('defaults.yaml'), load('shoe3.ys'))
+```
+
+And then:
+
+```bash
+$ ys -Y shoes.yaml 
+- size: 10
+  color: red
+  name: sneaker
+- size: 10
+  color: black
+  name: boot
+- size: 8
+  color: blue
+  name: sandal
+```
+
+There we go!
+
+
+## There's More Than One Way To Do It
+
+I was raised by Perl wolves! (well, Monks in wolf's clothing)
+
+As we progress through the Summer of YS, you'll notice Perlisms showing up here
+and there.
+For all its warts, Perl is has a lot of gems.
+Maybe that's what Matz was thinking when he created Ruby and based so much of it
+on Perl?
+I've stolen many of those shiniest gems for YS.
+
+Anyway, in YS… TMTOWTDI!
+
+----
+
+Let's rearrange our new shoes a bit:
+
+```yaml
+--- !YS-v0
+defaults =:
+  load: 'defaults.yaml'
+
+--- !YS-v0:
+- ! defaults.merge(load('shoe1.yaml'))
+- !
+  merge defaults:
+    load: 'shoe2.json'
+- !:merge*
+  - ! defaults
+  - ! load('shoe3.ys')
+```
+
+And we get:
+
+```bash
+$ ys -Y shoes.yaml 
+- size: 10
+  color: red
+  name: sneaker
+- size: 10
+  color: black
+  name: boot
+- size: 8
+  color: blue
+  name: sandal
+```
+
+----
+
+That's a lot of new YS syntax to unpack, but the surf's up! :surfer:
+
+See you again tomorrow!

--- a/blog/2025-06-05.md
+++ b/blog/2025-06-05.md
@@ -1,0 +1,144 @@
+---
+title: YS Curling (up North)
+date: 2025-06-05
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-05.md
+comments: true
+---
+
+Ever been to Manitoba?
+I went there once when my flight from Seattle to Toronto diverted to Winnipeg
+because the plane's toilets stopped working!
+That's when I learned about the [World's Largest Curling Rock](
+https://www.winnipeg.ca/tourism/attractions/worlds-largest-curling-rock).
+
+!!! note "Toronto DevOps Meetup"
+
+    Speaking of Toronto, I'll be giving a talk called ["The YS way to YAML"](
+    https://www.meetup.com/toronto-enterprise-devops-user-group/events/307801910/)
+    at the Toronto DevOps Meetup on June 12th.
+    That's one week from today!
+
+    If you're in town I hope to see you there!
+
+Today we'll be doing a little curling with YS.
+
+<!-- more -->
+
+
+## Curling Web Data in YS
+
+[Yesterday](/blog/2025-06-04/load-and-compose-your-yaml-files/) we learned how
+load data from other files.
+
+Today we'll go a bit further on that and also learn how to load data from the
+web.
+
+We have some nice shoes but we don't have anyone to wear them.
+We can fix that.
+I know of a big list of people who would love to try them on, and the list is
+[a JSON array on the web](
+https://github.com/dominictarr/random-name/raw/master/first-names.json)!
+
+Let's use YS to play around with that list.
+
+```bash
+$ ys -J -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+json =: curl(url)
+list =: json/load(json)
+people =:
+  take 3: list
+say: count(list)
+say: people
+'
+4946
+(Aaren Aarika Abagael)
+```
+
+It looks like the "curling" function is called `curl` and it's built in.
+There's also a JSON loading built-in and a few other handy functions like `take`
+and `count`.
+
+4946 is a lot of people!
+But why limit ourselves to the first 3?
+A random selection of 3 is a lot more fun!
+
+```bash
+$ ys -J -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+json =: curl(url)
+list =: json/load(json)
+people =: list.shuffle().take(3)
+say: people
+'
+(Johnna Korrie Elayne)
+```
+
+I like that better.
+
+Did you notice the new function chaining syntax in `list.shuffle().take(3)`?
+We'll get into that a lot more later on, but let's have a little fun with it
+right now.
+
+```bash
+$ ys -J -e 'ARGS.0.curl().json/load().shuffle().take(3).say()' \
+-- https://github.com/dominictarr/random-name/raw/master/first-names.json
+(Madlen Joete Daveta)
+```
+
+That's pretty cool.
+We did everything in a single (chained) expression.
+Chaining functions together is one of the most powerful features of YS.
+
+
+## Put Your Shoes on!
+
+We have a list of people and a list of shoes.
+Let's pair them up!
+
+```bash
+$ ys -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+
+people =: url.curl().json/load().shuffle().take(3)
+shoes =: read("shoes.yaml").yaml/load()
+
+say: str(people.0, " wears size ", shoes.0.size, " ", join([shoes.0.name, "s"]))
+say: str(people.1, " wears size ", shoes.1.size, " ", join([shoes.1.name, "s"]))
+say: str(people.2, " wears size ", shoes.2.size, " ", join([shoes.2.name, "s"]))
+'
+Shanon wears size 10 sneakers
+Henrie wears size 10 boots
+Sybil wears size 8 sandals
+```
+
+Looking good!
+
+> The shoes I mean.
+> The code could be be way nicer.
+> It will, but not today.
+
+Notice that instead of using `load` on `shoes.yaml` we used `read` and
+`yaml/load`.
+TMTOWTDI strikes again!
+
+
+## Programming with YS
+
+So far we've been using YS to enhance YAML files.
+But can we use YS to write programs?
+
+Well, we just did exactly that!
+
+I wasn't expecting to show you that today, but that's just how it worked out.
+And we did all of it using YS `-e` one liners.
+
+That last program is just begging to use loops and string formatting, right?
+
+We'll get there, but for now let's get out in the sun and do some curling!

--- a/blog/2025-06-06.md
+++ b/blog/2025-06-06.md
@@ -1,0 +1,125 @@
+---
+title: Loops and Strings
+date: 2025-06-06
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-06.md
+comments: true
+---
+
+Yesterday I left you with a program that really needed to "YS up"!
+
+```bash
+$ ys -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+
+people =: url.curl().json/load().shuffle().take(3)
+shoes =: read("shoes.yaml").yaml/load()
+
+say: str(people.0, " wears size ", shoes.0.size, " ", join([shoes.0.name, "s"]))
+say: str(people.1, " wears size ", shoes.1.size, " ", join([shoes.1.name, "s"]))
+say: str(people.2, " wears size ", shoes.2.size, " ", join([shoes.2.name, "s"]))
+'
+```
+
+Let's make this awesome!
+
+<!-- more -->
+
+
+## YS Interpolation
+
+Great interpolation is something I want in every language I program in.
+I don't always get it, but if I'm going to invent a new language, it's a must.
+
+Interpolation is the ability to expand variables or expressions into a string,
+in place.
+
+Here's a quick example of both in YS:
+
+```yaml
+# File 'add'
+!YS-v0
+a b =: ARGS
+say: "$a + $b = $(a + b)"
+```
+
+When we run it like this:
+
+```bash
+$ ys add 16 26
+16 + 26 = 42
+```
+
+That's so simple.
+Both to write and for others to understand.
+
+YS allows interpolation in double quoted strings and also literal strings (the
+`|` syntax) when the string is in "code mode".
+Just use `$var` or `$(expr)` to evaluate and expand them in place.
+
+Let's use interpolation in our shoes program.
+
+```bash
+$ ys -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+
+people =: url.curl().json/load().shuffle().take(3)
+shoes =: read("shoes.yaml").yaml/load()
+
+say: "$(people.0) wears size $(shoes.0.size) $(shoes.0.name)s"
+say: "$(people.1) wears size $(shoes.1.size) $(shoes.1.name)s"
+say: "$(people.2) wears size $(shoes.2.size) $(shoes.2.name)s"
+'
+Rebecca wears size 10 sneakers
+Dian wears size 10 boots
+Iolande wears size 8 sandals
+```
+
+Better!
+
+Let's make it better still!
+
+
+## Loops
+
+We could make this better if only YS had loops!
+
+Pffft.
+We got your looping constructs right here!
+Several of them!
+
+Let's use the `each` looping function for this.
+
+```bash
+$ ys -e '
+url =:
+  "https://github.com/dominictarr/random-name/raw/master/first-names.json"
+
+people =: url.curl().json/load().shuffle().take(3)
+shoes =: read("shoes.yaml").yaml/load()
+
+each i range(people.count()):  # (0, 1, 2)
+  person =: people.$i
+  shoe =: shoes.$i
+  say: "$person wears size $(shoe.size) $(shoe.name)s"
+'
+Myrtle wears size 10 sneakers
+Phillis wears size 10 boots
+Evonne wears size 8 sandals
+```
+
+I like it!
+
+
+## Take your shoes off!
+
+By this time I bet you're getting tired of seeing programs about shoes.
+
+Me too.
+Tomorrow will be different. Promise.
+
+It's Summertime, let's go barefoot!

--- a/blog/2025-06-07.md
+++ b/blog/2025-06-07.md
@@ -1,0 +1,208 @@
+---
+title: TMTOWTDI for YS Expressions
+date: 2025-06-07
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-06.md
+comments: true
+---
+
+Like I said before, in YS, There's More Than One Way To Do It.
+
+This is especially true for YS expressions.
+
+Later on you'll learn that YS is a Lisp in disguise.
+In Lisp, an expression is a list consisting of a function and its arguments
+inside a set of parentheses.
+
+Consider this Python code:
+
+```python
+name = "World"
+print("Hello, " + name + "!")
+```
+
+In a Lisp, this would be written as:
+
+```lisp
+(def name "World")
+(println (str "Hello, " name "!"))
+```
+
+In YS, this _could_ be written as:
+
+```yaml
+name =: 'World'
+say: str('Hello, ' name '!')
+```
+
+I say _could_ because... TMTOWTDI!
+
+Today I'm going to show you many of the ways to DO IT in YS.
+
+<!-- more -->
+
+
+## How YS Relates to YAML
+
+The first thing to remember is that all YS code has to be 100% valid YAML.
+So essentially we need to be able to write any possible Lisp code as YAML!
+
+Since YS wants to be clean like YAML is clean, it offers you several ways to
+write the same Lisp expression, make it look clean and still be valid YAML.
+
+!!! note
+
+    The YS compiler's first job is to "parse" the YAML input.
+    "Parse" doesn't mean the entire operation of turning YAML into a data
+    structure.
+    YAML calls that operation "loading" and it consists of many steps, the first
+    of which is to "parse" the YAML into a stream of events (structs).
+
+    The YS compiler is literally a YAML loader.
+    Writing a YAML parser is by far the most complex part of writing a YAML
+    loader, so YS uses a third-party parser for that part.
+    Therefore anything that is not valid to that parser is not valid YS code!
+    We'll talk about the YS compiler in detail later this summer.
+
+YS only uses YAML block mappings (the normal indented mapping style) and YAML
+scalars to represent code.
+
+!!! note "Handy Tip"
+
+    If you ever see a YAML block sequence (the stuff that starts with `- `) or a
+    YAML flow collection (the `{...}` or `[...]` stuff), it's not YS "code",
+    it's just normal YAML"data".
+    In other words that YS node is in "data mode" not "code mode".
+
+In code mode, a mapping is a set of expressions, where each key/value pair is
+an expression.
+
+Consider this YS code:
+
+```bash
+$ ys -e '
+name =: "World"
+say:
+  str: "Hello, ", name, "!"
+'
+Compile error: while parsing a block mapping
+ in reader, line 5, column 3:
+      str: "Hello, ", name, "!"
+      ^
+expected <block end>, but found ','
+ in reader, line 5, column 17:
+      str: "Hello, ", name, "!"
+```
+
+What went wrong?
+
+Look at this code as regular YAML.
+You can't have any text after a double quoted string, right?
+This is a parser error.
+
+To get around this, YS has a special escape character.
+`+ "Hello, " + name + "!"` turns that whole value code into a plain (unquoted)
+YAML scalar.
+The `+` is removed and the rest gets compiled as part of an expression.
+
+Let's try again:
+
+```bash
+$ ys -e '
+name =: "World"
+say:
+  str: + "Hello, ", name, "!"
+'
+Hello, World!
+```
+
+Better.
+
+
+## Commas Aside
+
+Time to let you in on a little secret.
+
+In YS code, Commas are Whitespace!
+
+The commas separating the arguments above were not necessary.
+
+```bash
+$ ys -e '
+name =: "World"
+say:
+  str: "Hello, " name "!"
+'
+Hello, World!
+```
+
+Commas _are_ necessary in YAML flow collections though.
+
+It is idiomatic YS to not use commas in code mode unless they really add
+clarity.
+
+That way, when you do see commas, you'll know you are likely in data mode.
+
+
+## More Ways to Do It
+
+Let's look at several ways to write that "say Hello World" expression.
+
+```bash
+$ ys -e '
+name =: "World"
+
+# Block form
+say:
+  str: + "Hello, " name "!"
+
+# Lisp form
+say: (str "Hello, " name "!")
+
+# YS call form
+say: str("Hello, " name "!")
+
+# Chained form
+=>: str("Hello, " name "!").say()
+
+# Chained colon form
+=>: str("Hello, " name "!"):say
+
+# Tag function form
+=>: !:say
+  str: + "Hello, " name "!"
+
+# Or
+=>: !:say
+  str("Hello, " name "!")
+'
+Hello, World!
+Hello, World!
+Hello, World!
+Hello, World!
+Hello, World!
+Hello, World!
+Hello, World!
+```
+
+I'll explain each of these forms more as we go.
+
+For now, 2 things.
+
+`foo:bar:baz` is shorthand for `foo.bar().baz()`.
+You can optionally use `:xyz` instead of `.xyz()` when chaining a function call
+that takes no arguments.
+
+And what's the `=>` thing?
+
+Remember, YS is YAML and we are in a YAML block mapping.
+We can't use expressions where some are key/value pairs and some are plain
+scalars.
+When we have something that is just a scalar, we can make it a pair by adding
+the `=>` placeholder key.
+
+OK! It's time to get on with my Summer weekend!
+
+See you next time!

--- a/blog/2025-06-08.md
+++ b/blog/2025-06-08.md
@@ -1,0 +1,346 @@
+---
+title: In The Beginning
+date: 2025-06-08
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-08.md
+comments: true
+---
+
+How did YAML get started in the first place?
+
+Today's Sunday post is about YAML, not YS.
+
+But since YS is YAML, I think that's OK.
+
+This is the story of how the [YAML data language](
+https://en.wikipedia.org/wiki/YAML) got its start as far back as [1999](
+https://www.youtube.com/watch?v=rblt2EtFfC4).
+
+!!! note "React and Comment here please!!!"
+
+    I'm not sure how many people are reading this series, but I'm enjoying
+    writing it.
+    It's nice to know that I'm not alone on this Summer journey.
+
+    I recently added Reactions and Comments support to these blog posts.
+    Scroll down to the bottom of each post to see them.
+
+    If you are enjoying the [**Summer of YS**](
+    http://0.0.0.0:8000/blog/category/summer-of-ys/) series, please don't forget
+    to react (and comment if you want to) to let me know!
+
+<!-- more -->
+
+!!! note
+
+    I originally wrote this blog post [back in 2020](
+    https://yaml.com/blog/2020-12/in-the-beginning/) but I thought it would be
+    a good addition to the Summer of YS series.
+
+
+## (Read the following) like it's 1999
+
+The web was taking over the world.
+
+Rich content was flying around the globe and into your eyeballs in milliseconds,
+all delivered as a plain text package.
+
+HTML!
+
+Amazing!
+
+Hey, let's abstract HTML/SGML a bit and it will become the end-all format for
+all the world's data communication.
+
+We'll call it XML!
+
+What could go wrong?!
+
+Hold on...
+XML?
+Really?
+I thought this was a story about YAML.
+What does XML have to do with it?
+
+Patience...
+
+
+## Whence YAML?
+
+According to my records...
+
+* The first mention of "YML" was by Clark Evans on
+  `Tue, 30 Nov 1999 22:27:00 -0500 (EST)`
+* The first mention of "YAML" was by Simeon Simeonov on
+  `Mon, 14 Feb 2000 13:10:34 -0800`
+* Clark announced his purchase of [yaml.org](https://yaml.org) on
+  `Fri, 5 Jan 2001 02:50:35 -0500 (EST)`
+* Clark published "YAML Draft 0.1" on `Fri, 11 May 2001 15:50:31 -0500`,
+  claiming:
+    * YAML is a straight-forward markup language, offering an alternative to XML,
+      borrowing ideas from C, HTML, Perl, and Python.
+    * YAML texts are brief and readable.
+    * YAML is very expressive and extensible.
+    * YAML has a simple stream based interface.
+    * YAML uses data structures native to your programming language.
+    * YAML is easy to implement, perhaps too easy.
+    * YAML has a solid information model, no exceptions no mess.
+* Clark was made aware of Brian Ingerson and his work on
+  [Data::Denter](https://metacpan.org/pod/Data::Denter) on
+  `Sun, 13 May 2001 15:39:53 -0000`
+    * Hey! That's me!!!
+    * Brian was rebranded to Ingy in 2005 :)
+
+Where are these "records"?
+Patience...
+
+
+### Primordial YAML
+
+Here's one of Clark's earliest stabs at YAML:
+```
+$invoice           00034843
+$date              12-JAN-2001
+%buyer
+    $given-name    Chris
+    $family-name   Dumars
+    %address
+        $line1     458 Wittigen's Way
+        $line2     Suite #292
+        $city      Royal Oak
+        $state     MI
+        $postal    48046
+@order
+    %product
+        $id        BL394D
+        $desc      Grade A, Leather Hide Basketball
+        $price     $450.00
+        $quantity  4
+    %product
+        $id        BL4438H
+        $desc      Super Hoop (tm)
+        $price     $2,392.00
+        $quantity  1
+$comments
+    Mr. Dumars is frequently gone in the morning
+    so it is best advised to try things in late
+    afternoon. \nIf Joe isn't around, try his house\
+    keeper, Nancy Billsmer @ (734) 338-4338.
+%delivery
+    $method        UZS Express Overnight
+    $price         $45.50
+$tax               0%
+$total             $4237.50
+```
+
+Sjoerd Visscher countered with something that may have inspired YAML's "flow"
+(think JSON) style:
+```
+%[
+  invoice            [00034843]
+  date               [12-JAN-2001]
+  buyer %[
+      given-name     [Chris]
+      family-name    [Dumars]
+      address %[
+          line1      [458 Wittigen's Way]
+          line2      [Suite #292]
+          city       [Royal Oak]
+          state      [MI]
+          postal     [48046]
+      ]
+  ]
+  product @[
+      %[
+          id         [BL394D]
+          desc       [Grade A, Leather Hide Basketball]
+          price      [$450.00]
+          quantity   [4]
+      ]
+      %[
+          id         [BL4438H]
+          desc       [Super Hoop (tm)]
+          price      [$2,392.00]
+          quantity   [1]
+      ]
+  ]
+  comments[
+      Mr. Dumars is frequently gone in the morning
+      so it is best advised to try things in late
+      afternoon. \nIf Joe isn't around, try his house\
+      keeper, Nancy Billsmer @ (734) 338-4338.
+  ]
+  delivery%[
+      method         [UZS Express Overnight]
+      price          [$45.50]
+  ]
+  tax                [$0.00]
+  total              [$4237.50]
+]
+```
+
+The next day, Oren Ben-Kiki offered:
+```
+invoice:            00034843
+date:             12-JAN-2001
+buyer:
+    given name:   Chris
+    family name:  Dumars
+    address: %
+        line1:    458 Wittigen's Way
+        line2:    Suite #292
+        city:     Royal Oak
+        state:    MI
+        postal:   48046
+    : %
+        id:       BL394D
+        desc:     Grade A, Leather Hide Basketball
+        price:    $450.00
+        quantity: 4
+    : %
+        id:       BL4438H
+        desc:     Super Hoop (tm)
+        price:    $2,392.00
+        quantity: 1
+comments:
+    Mr. Dumars is frequently gone in the morning
+    so it is best advised to try things in late
+    afternoon. \nIf Joe isn't around, try his house\
+    keeper, Nancy Billsmer @ (734) 338-4338.
+delivery:
+    method:     UZS Express Overnight
+    price:      $45.50
+tax:            $0.00
+total:          $4237.50
+```
+
+Spooky...
+
+Now we're cooking with nitro!
+
+
+## Back to XML
+
+OK, cool, but what's any of this got to do with XML?
+
+Back then Clark Evans, Oren Ben-Kiki and a host of others were trying to figure
+out how to make XML simpler.
+This world-wide discussion happened on the
+[XML-DEV](http://www.xml.org/xml-dev/) mailing list, starting in 1997 and
+continuing until at least last Wednesday.
+In November 1999 a faction of that list started talking about SML, a simpler
+more minimal XML.
+They decided to create their own SML-DEV mailing list.
+It was there that Clark and Oren eventually decided to break away from angle
+brackets altogether and... YAML was born.
+
+At that time Ingy had landed a job in Open Source Heaven (aka ActiveState) and
+was sitting in a row of Perl programmers, across from a row of Python
+programmers.
+He was working on the Perl core's plain text serialization language,
+Data::Dumper.
+In the Spring of 2001, he must have caught some Python fever, because he made
+Data::Denter, an indentation based serialization language module for CPAN.
+
+In May, he got an email from Clark which led to an hours long phone call.
+He couldn't stop muttering "YAML YAML YAML" for months.
+_Try it yourself. It just feels so good coming off the tongue!_
+
+
+## Back to SML
+
+Over the next 5 years or so, Oren, Clark and I(ngy) worked non-stop (on a
+mailing list of course) getting YAML off the ground.
+They mentioned SML from time to time.
+
+In 2017, I decided to look for the SML-DEV mailing list and to my surprise it
+still existed on yahoo.com!
+I searched the list to find out how I was brought into the mess in the first
+place.
+I found a single post from Jim Flanagan telling Clark about me, the same day
+that Clark reached out to me.
+
+```
+Date: Sun, 13 May 2001 15:39:53 -0000
+Subject: Re: YAML Draft 0.1
+In-Reply-To: <20010511155031.A30060@...>
+From: jimfl@...
+
+This looks very similar to the format of the Perl module Data::Denter
+(by Brian Ingerson) for which there is already a fine parser available
+(in perl, of course).
+
+See:
+
+http://search.cpan.org/doc/INGY/Data-Denter-0.12/Denter.pod
+```
+
+Next I searched for more info on Jim and it turns out we lived in the same city.
+Practically the same neighborhood!
+I emailed the unwitting catalyst of modern day YAML and invited him to lunch.
+We had sushi.
+
+In 2020 I went back to the SML list to look for something and got hit with:
+
+```
+Announcement: End of Yahoo Groups We’re shutting down the Yahoo Groups website
+on December 15, 2020 and members will no longer be able to send or receive
+emails from Yahoo Groups. Yahoo Mail features will continue to function as
+expected and there will be no changes to your Yahoo Mail account, emails,
+photos or other inbox content. There will also be no changes to other Yahoo
+properties or services. You can find more information about the Yahoo Groups
+shutdown and alternative service options on this help page.
+```
+
+Boooooo!
+
+Not only that, I could no longer see the SML-DEV content.
+
+After a few tears, the internet graciously led me to archive.org where I found
+the entire SML-DEV list (every email!) downloadable as a [single file](
+https://archive.org/download/yahoo-groups-2016-06-18T17-13-11Z-9329be/sml-dev.sbxL0kc.warc.gz)!
+Hmmm... `.warc.gz`.
+I know `gz` but `warc` looked scary.
+
+I took a closer look inside and it was actually quite simple.
+
+WARC is the Web ARChive format!
+Just an alternation of plain text header lines and JSON payloads. 
+
+Since JSON is a proper subset of YAML, I figured I could handle it.
+
+The next morning I cobbled together a [shell command pipeline](
+https://github.com/yaml/sml-dev-archive/tree/master/fetch) that turned 5000+
+emails into a nice readable plain text file that I've been scouring and
+devouring ever since.
+I threw the whole schmear up onto a [GitHub repository](
+https://github.com/yaml/sml-dev-archive#readme) so you can [read it](
+https://raw.githubusercontent.com/yaml/sml-dev-archive/master/sml-dev.txt) too.
+
+
+## Back to the Future
+
+There is such a long and rich history of how YAML got here.
+I could go on for days.
+Perhaps I'll get back to some of that in a later post.
+
+My focus is currently (as it's been since 2001) on the Future of YAML.
+I want to tell you where YAML is _going_!!!
+
+There's a lot of fantastic new activity in the YAML language, and some new
+dedicated people helping to move it forward.
+We can't wait to share more of the YAML adventure as it unfolds...
+
+
+## Back to the Summer
+
+Did you think YAML was created to be a configuration language?
+
+We never even considered it back then.
+
+Sometimes the world decides for you.
+
+Later on I tell you more about YAML's history, but for now I'm gonna enjoy this
+Summer Sunday.

--- a/blog/2025-06-09.md
+++ b/blog/2025-06-09.md
@@ -1,0 +1,59 @@
+---
+title: Functionally Speaking
+date: 2025-06-09
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-09.md
+comments: true
+---
+
+YS is a functional programming language.
+
+Therefore we should be able to write functions in YS.
+
+This week I want to do a mini-series of blog posts about using and writing
+functions in YS.
+
+Let's get started!
+
+<!-- more -->
+
+
+## Defining Functions
+
+
+Defining functions in YS is easy.
+
+```yaml
+# File: add.ys
+!YS-v0
+
+defn add(a b):
+  a + b
+
+say: add(ARGS*)
+```
+
+Let's run it:
+
+```
+$ ys add.ys 3 4 5 6 7 8 9
+42
+```
+
+Nice!
+
+
+## Return Values
+
+In YS (like other Lisp influenced languages) the last expression in a function
+is the return value.
+
+You don't use a `return` keyword to return a value.
+
+With that said, I'm going to "return" to my Summer afternoon.
+
+I know this was a short post, but, well, the day kind of got away from me.
+
+I'll have a lot more tomorrow.

--- a/blog/2025-06-10.md
+++ b/blog/2025-06-10.md
@@ -1,0 +1,168 @@
+---
+title: Where the Funcs Have No Name
+date: 2025-06-10
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-10.md
+comments: true
+---
+
+Any self-respecting functional language has a way to create anonymous functions.
+
+In YS there are more than one!
+
+Today we'll talk about nameless functions, why they are useful, and how to create and call them.
+
+<!-- more -->
+
+
+## What are anonymous functions good for?
+
+A functional language has lots of functions, and a lot of those functions take
+functions as arguments and/or return functions.
+
+For example, the `map` function takes a function and a list, and applies the
+function to each element of the list.
+
+Here we square the numbers 1 through 10.
+
+```bash
+$ ys -pe 'map sqr: 1 .. 10'
+(1 4 9 16 25 36 49 64 81 100)
+```
+
+The `sqr` function is part of the YS standard library.
+So is `cube`.
+But what about `quarq` (I just made that up) raising a number to the fourth power?
+
+We could write a function for that:
+
+```bash
+$ ys -pe '
+defn quarq(x): x ** 4
+map quarq: 1 .. 10'
+(1 16 81 256 625 1296 2401 4096 6561 10000)
+```
+
+But we could also write an anonymous function:
+
+```bash
+$ ys -pe 'map \(_ ** 4): 1 .. 10'
+(1 16 81 256 625 1296 2401 4096 6561 10000)
+```
+
+
+## The anonymous function syntax
+
+As you just saw, you create an anonymous function with the `\( ... )` syntax.
+
+!!! note
+
+    The `\` is supposed to remind you of the `λ` symbol in lambda calculus which
+    is all about anonymous functions.
+    Haskell also uses `\` for anonymous functions.
+
+The `_` is a symbol for the first argument.
+It can also be written as `%1`
+
+Consider this example:
+
+```bash
+$ ys -pe 'apply \(%1 * %3 * %5): 1 .. 10'
+15
+```
+
+We'll discuss `apply` in a future post, but notice how we multiplied the first,
+third, and fifth elements of the list `1 .. 10` without caring about the second
+or fourth elements?
+
+
+## The `fn` function
+
+The `fn` function defines a function.
+It's what `defn` uses except that you don't need to give it a name.
+
+These all do the same thing:
+
+```yaml
+defn quarq(x): x ** 4
+
+quarq =: \(_ ** 4)
+
+quarq =:
+  fn(x): x ** 4
+
+quarq =: fn([x] (x ** 4))
+```
+
+
+## Higher order YS
+
+
+!!! note "https://en.wikipedia.org/wiki/Higher-order_function"
+
+    In mathematics and computer science, a higher-order function (HOF) is a function that does at least one of the following:
+
+    - Takes one or more functions as arguments (i.e. a procedural parameter,
+      which is a parameter of a procedure that is itself a procedure),
+    - Returns a function as its result.
+
+Let's write a function that returns a function.
+
+Say we have a list of lengths in feet, meters, yards, or fathoms and we want to
+convert them to one of the other units.
+
+We could write a function for each conversion or we could write a function that
+returns a function.
+
+Convert a list of lengths from one unit to another
+
+```yaml
+# convert,ys
+!YS-v0
+
+defn main(from to *nums):
+  each x nums:
+    converter =: converter-maker(from to)
+    say: "$x $from is $(converter x) $to"
+
+foot =::
+  meters: 3.28084
+  fathoms: 6.0
+  feet: 1.0
+  yards: 3.0
+
+defn converter-maker(a b):
+  fn(x):
+    x / foot.$b *: foot.$a
+```
+
+The `converter-maker` function takes the names of 2 units and returns a function
+that converts a number from the first unit to the second unit.
+
+Let's run it:
+
+```bash
+$ ys convert.ys fathoms meters 2 3 5 7 11 13
+2 fathoms is 3.657599882956804 meters
+3 fathoms is 5.486399824435206 meters
+5 fathoms is 9.143999707392009 meters
+7 fathoms is 12.801599590348811 meters
+11 fathoms is 20.11679935626242 meters
+13 fathoms is 23.774399239219225 meters
+```
+
+Fathom that!
+
+Ok, it's Summer hammock time.
+
+See you tomorrow!
+
+----
+
+!!! note
+
+    If you made it this far, don't forget to add a reaction and please leave a
+    comment if you have something to ask or say.
+    I'd appreciate it!

--- a/blog/2025-06-11.md
+++ b/blog/2025-06-11.md
@@ -1,0 +1,131 @@
+---
+title: YS Multi Functions
+date: 2025-06-11
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-11.md
+comments: true
+---
+
+Many languages let you define functions with multiple signatures.
+
+That is, you can have multiple functions with the same name but different
+arguments.
+
+YS supports multi-arity functions.
+It dispatches on the number of arguments.
+
+Let's see how it works.
+
+<!-- more -->
+
+
+## Extending `defn`
+
+Let's concoct a multi-arity function called `weird` that does the following
+based on the number of numbers it is given:
+
+* 1 number: returns the square of the number
+* 2 numbers: returns the sum of the numbers
+* 3 numbers: returns the product of the numbers
+
+```yaml
+# weird.ys
+!YS-v0
+defn weird:
+  (x): x ** 2
+  (x y): x + y
+  (x y z): x * y * z
+
+say: weird(3)
+say: weird(3 5)
+say: weird(3 5 7)
+say: weird(3 5 7 9)
+```
+
+And let's run it:
+
+```
+$ ys weird.ys
+9
+8
+105
+Error: Cannot call weird with 4 arguments
+```
+
+It works as expected.
+
+When we defined the function we didn't use any parens after the function name.
+Then we specified a key/value pair for each different function signature and
+body.
+
+
+## What about any number of arguments?
+
+Now let's modify the `weird` function to take any number of arguments.
+If it gets 4 or more, let's turn them into a string that is the list of the
+numbers separated by commas.
+
+```yaml
+# weird.ys
+!YS-v0
+defn weird:
+  (x): x ** 2
+  (x y): x + y
+  (x y z): x * y * z
+  (*more): more.join(', ')
+
+nums =: 1 .. 10
+say: weird(nums*)
+```
+
+And:
+
+```
+$ ys weird.ys
+1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+```
+
+Cool.
+An argument with a `*` in front of it means "any number of arguments" and
+collects them into a list.
+
+We can then "splat" or "unpack" the list into multiple arguments by placing a
+"*" after the variable name when used in a function call.
+
+
+## A common use case
+
+Let's create a function called `add` that takes any number of arguments and
+returns the sum of the arguments.
+
+```yaml
+# add.ys
+!YS-v0
+defn add:
+  (): 0
+  (x): x
+  (x y): x + y
+  (x y *xs):
+    reduce add: (x + y) xs
+
+add: 1 2 3 4 5
+```
+
+And:
+```
+$ ys add.ys
+15
+```
+
+Here when we have more than 2 arguments, we use recursion to add the numbers.
+You'lll have to wait for another day to learn how reduce works (but it's really
+simple).
+
+!!! note
+
+    YS has a standard library function called `add` and that's exactly how it is
+    implemented!
+
+See you next time!

--- a/blog/2025-06-12.md
+++ b/blog/2025-06-12.md
@@ -1,0 +1,124 @@
+---
+title: Using Environment Variables
+date: 2025-06-12
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-12.md
+comments: true
+---
+
+Tonight I'm giving a talk about YS and YAML to the [Toronto DevOps Meetup](
+https://www.meetup.com/toronto-enterprise-devops-user-group/events/307801910/).
+
+What could be more important to a developer than environment variables?!
+
+Let me show you how to use environment variables in YS and in your YAML files.
+
+<!-- more -->
+
+
+## The Environment is just a Simple Map
+
+A shell environment is just a simple map of strings to strings.
+
+In YS, this mapping is called `ENV`.
+
+!!! note "'ENV' is a normal symbol"
+
+    Later we'll talk about YS symbols (names of variables), but they are just
+    kebab-case alphanumeric strings.
+    Case doesn't matter.
+    By convention however, YS uses all uppercase for special global variables
+    like `ENV`.
+
+Let's see how to use `ENV` in YS.
+
+```bash
+$ $ ys -e 'say: "Hi there. I am $(ENV.USER.uc1())."'
+Hi there. I am Ingy.
+```
+
+My system username is `ingy`, and the environment puts the username in the
+`USER` variable:
+
+```bash
+$ whoami
+ingy
+$ echo $USER
+ingy
+```
+
+The `uc1()` function converts the first letter to uppercase.
+
+
+## Using Environment Variables in YAML
+
+What if your YAML file could load different values for different environments?
+For instance it could use different database credentials for dev, test, stage
+and prod.
+
+Let's see how to do that.
+
+First our main config file:
+
+```yaml
+# config.yaml
+YS-v0:
+vars =:
+  load:
+    case ENV.ENVIRONMENT:
+      'dev': 'dev-vars.yaml'
+      'test': 'test-vars.yaml'
+      'staging': 'staging-vars.yaml'
+      'prod': 'prod-vars.yaml'
+      else:
+        die: "The 'ENVIRONMENT' variable must be one of
+              'dev', 'test', 'staging', or 'prod'"
+
+# Or just:
+vars =: load("$(ENV.ENVIRONMENT)-vars.yaml")
+
+database:
+  host:: vars.db-host
+  port:: vars.db-port
+  user:: vars.db-user
+  password:: vars.db-password
+```
+
+Then our environment-specific variables files:
+
+```yaml
+# dev-vars.yaml
+db-host: 127.0.0.1
+db-port: 5432
+db-user: dev
+db-password: d3v
+```
+
+Let's load the `config.yaml` file with `ys -Y`:
+
+```bash
+$ ys -Y config.yaml
+Error: The 'ENVIRONMENT' variable must be one of 'dev', 'test', 'staging', or 'prod'
+```
+
+Oops!
+We forgot to set the `ENVIRONMENT` variable!
+
+```bash
+$ export ENVIRONMENT=dev
+$ ys -Y config.yaml
+database:
+  host: 127.0.0.1
+  port: 5432
+  user: dev
+  password: d3v
+```
+
+That's a pretty good setup.
+
+We can make it even more streamlined, but we'll save that for another time.
+
+I have a talk to finish writing!!!
+So I'll see you next time!

--- a/blog/2025-06-13.md
+++ b/blog/2025-06-13.md
@@ -1,0 +1,72 @@
+---
+title: YS Global Variables
+date: 2025-06-13
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-13.md
+comments: true
+---
+
+Last night a gave a talk about YS and YAML to the [Toronto DevOps Meetup](
+https://www.meetup.com/toronto-enterprise-devops-user-group/events/307801910/).
+
+I had a lot of fun, and met a lot of great people.
+
+Today I'm going to share one of the things I covered last night.
+Global variables.
+
+It's not the most exciting topic, but it can be useful.
+
+<!-- more -->
+
+
+## YS has some predefined global variables
+
+Yesterday I we talk about the `ENV` variable which is one of the predefined
+global variables.
+It's probably the most useful one.
+
+But there are other ones that you can use too.
+
+
+### Stdio Handles
+
+* `IN` - Standard Input file handle
+
+* `OUT` - Standard Output file handle
+
+* `ERR` - Standard Error file handle
+
+
+### Command Line Arguments
+
+* `ARGV` - A program's command line arguments. A vector of strings.
+
+* `ARGS` - Same as `ARGV` but as but args the look like numbers are converted
+  to numbers.
+
+
+### File System
+
+* `FILE` - The absolute path to the program's file.
+
+* `DIR` - The absolute path to the program's directory.
+
+* `CWD` - The current working directory.
+
+
+### Runtime Values
+
+* `RUN`- A map of a few runtime values:
+    * `RUN.bin` - The absolute path to the directory of the `ys` binary.
+    * `RUN.pid` - The process ID of the current process.
+    * `RUN.versions` - The versions of key components in the `ys` binary.
+
+* `VERSION` - The version of the `ys` binary.
+
+
+That's all for today.
+Headed out for a weekend of Summertime camping.
+
+We you tomorrow if there's wifi in the woods!

--- a/blog/2025-06-13.md
+++ b/blog/2025-06-13.md
@@ -69,4 +69,4 @@ But there are other ones that you can use too.
 That's all for today.
 Headed out for a weekend of Summertime camping.
 
-We you tomorrow if there's wifi in the woods!
+See you tomorrow if there's wifi in the woods!

--- a/blog/2025-06-14.md
+++ b/blog/2025-06-14.md
@@ -16,7 +16,7 @@ They'll, well, um... Functions.
 
 So what's the big deal?
 
-<!--more-->
+<!-- more -->
 
 
 ## Functions have their own scope

--- a/blog/2025-06-14.md
+++ b/blog/2025-06-14.md
@@ -1,0 +1,93 @@
+---
+title: if - You Have to Ask!
+date: 2025-06-14
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-14.md
+comments: true
+---
+
+Today we're going to look at the `if` command.
+
+In a functional language, `if` statements are a bit different.
+
+They'll, well, um... Functions.
+
+So what's the big deal?
+
+<!--more-->
+
+
+## Functions have their own scope
+
+So if `if` is a function then you can't use it to set state outside of its
+scope.
+Let me show you what I mean.
+
+Consider this normal Python code:
+
+```bash
+$ python -c '
+x = 500
+if x > 100:
+  size = "big"
+else:
+  size = "small"
+print(size)
+'
+big
+```
+
+This will set `size` to `"big"` and then print it.
+
+Let's try the same thing in YS:
+
+```bash
+$ ys -e '
+x =: 500
+if x > 100:
+  size =: "big"
+  size =: "small"
+say: size
+'
+Error: Could not resolve symbol: size
+```
+
+Since `if` is a function, size  is a local variable inside it's scope.
+
+Well that's a bummer.
+
+How are we supposed to get simple stuff done with YS?
+
+It's simple once you've seen it:
+
+```bash
+$ ys -e '
+x =: 500
+size =:
+  if x > 100:
+    then: "big"
+    else: "small"
+say: size
+'
+big
+```
+
+We just need to make `if` return what we want and then assign it to a variable
+in the scope that we want it in.
+
+
+## But why `then` and `else`?
+
+We didn't have them in the first example.
+Why did we need them in the second example?
+
+Well actually we didn't need them.
+
+But if I'm honest, right now I'm out in the woods (with wifi!) with friends who
+would rather have me hanging out doing Summer stuff than telling you about YS.
+
+So we'll save that for later...
+
+Maybe tomorrow!

--- a/blog/2025-06-15.md
+++ b/blog/2025-06-15.md
@@ -1,0 +1,105 @@
+---
+title: if - You Are Special
+date: 2025-06-15
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-15.md
+comments: true
+---
+
+Yesterday I told you that `if` is a function.
+
+I lied.
+
+In reality, `if` is a "special form".
+
+I'll explain special forms in a minute, but let's just say that they're
+"special"!
+
+<!--more-->
+
+
+## Functions calls evaluate their arguments
+
+Consider this code:
+
+```bash
+$ ys -e '
+x =:
+  DBG:
+    add:
+      sqr(4):DBG
+      sqr(5):DBG
+say: x
+'
+>>>16<<<
+>>>25<<<
+>>>41<<<
+41
+```
+
+`DBG` is a function that prints its arguments and then returns the value of the
+last one.
+
+We can see clearly that `sqr(4)` and `sqr(5)` are evaluated first, and then
+`add` is called with the results.
+
+Let's try the same thing with `if`:
+
+```bash
+$ ys -e '
+x =:
+  DBG:
+    if (rand(2):DBG > 1):DBG:
+      sqr(4):DBG
+      sqr(5):DBG
+say: x
+'
+>>>1.288428806185308<<<
+>>>true<<<
+>>>16<<<
+>>>16<<<
+16
+```
+
+It looks like `sqr(5)` was never evaluated.
+
+That's exactly how you want an `if` expression to work.
+
+An `if` expression is a function that takes three arguments:
+
+- A "condition clause"
+- A "then clause"
+- An "else clause"
+
+Based on the truthiness of the condition clause, only one of the other two
+clauses is evaluated.
+
+This is true in practically any programming language.
+
+
+## About Special Forms
+
+Most Lisp languages have special forms.
+
+Special forms "look" like functions in that they use parentheses containing the
+form name and any arguments.
+But they are built into the language to behave differently.
+
+YS has about a dozen special forms, and we've already been using them in this
+series.
+For example `x =: y` compiles into a Lisp `def` or `let` form (depending on
+the context) which are both special forms.
+
+
+
+## Fuggedaboud`if`!
+
+Now that you know about special forms, you can forget about them.
+
+In YS, everything's a function.
+A few of them are special.
+They all try to do the right thing.
+
+Enjoy the rest of your weekend!

--- a/blog/2025-06-15.md
+++ b/blog/2025-06-15.md
@@ -17,7 +17,7 @@ In reality, `if` is a "special form".
 I'll explain special forms in a minute, but let's just say that they're
 "special"!
 
-<!--more-->
+<!-- more -->
 
 
 ## Functions calls evaluate their arguments

--- a/blog/2025-06-16.md
+++ b/blog/2025-06-16.md
@@ -1,0 +1,121 @@
+---
+title: if - We Must
+date: 2025-06-16
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-16.md
+comments: true
+---
+
+Yesterday we talked about `if` being a special form.
+
+It turns out that `if` is special in other ways.
+For instance, it requires _both_ the `then` and `else` _clauses_ to be present…
+but… it doesn't require the actual `then` and `else` _keywords_.
+
+Today we'll finish our conversation about `if` and go over all the specifics.
+
+<!-- more -->
+
+
+## The Lisp Point of View
+
+In the Lisp code that YS compiles to, the form looks like this:
+`(if <condition> <then> <else>)`.
+
+!!! note
+
+    Lisp allows you to skip the `<else>` clause, in which case it defaults to
+    `nil`.
+    But it also discourages this, and encourages you to use the `when` function
+    instead.
+    We'll talk about `when` in a future post.
+
+    YS does not allow you to skip the `<else>` clause.
+    If you don't have one, use `nil` or switch to `when`.
+
+In YS we can write that in many ways:
+
+```yaml
+x =:
+  if a: b c
+x =:
+  if a:
+    =>: b
+    =>: c
+x =: if(a b c)
+x =: a.if(b c)
+```
+
+This works fine when the `<then>` and `<else>` clauses are a single form (both
+in Clojure and YS).
+
+If a clause needs more than one form you need to combine them into a single
+form.
+In Clojure you do this with a `do` form, and you can do that in YS too.
+The `do` form is a special form that evaluates all its arguments and returns the
+value of the last one.
+
+```yaml
+x =:
+  if a:
+    do:
+      b: 1
+      b: 2
+    do:
+      c: 1
+      c: 2
+```
+
+YS makes this prettier by allowing you to use the words `then` and `else`
+instead of `do` or `=>:`.
+
+```yaml
+$ ys -ce '
+x =:
+  if a:
+    then:
+      b: 1
+      b: 2
+    else:
+      c: 1
+      c: 2
+'
+(def x (if a (do (b 1) (b 2)) (do (c 1) (c 2))))
+```
+
+## The Fine Print
+
+In YS you can use `else` without using a `then` first, but if you use `then`
+you must use `else` too.
+You'll get an error if you don't.
+
+YS just reads better this way.
+
+```bash
+$ ys -ce '
+x =:
+  if a:
+    b: 1
+    else:
+      c: 1
+      c: 2
+'
+(def x (if a (b 1) (do (c 1) (c 2))))
+$ ys -ce '
+x =:
+  if a:
+    then:
+      b: 1
+      b: 2
+    c: 1
+'
+Compile error: Form after 'then' must be 'else'
+```
+
+Now you know all about `if`.
+
+There are several other cool conditional functions in YS.
+
+We'll get there!

--- a/blog/2025-06-17.md
+++ b/blog/2025-06-17.md
@@ -1,0 +1,100 @@
+---
+title: When to when
+date: 2025-06-17
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-17.md
+comments: true
+---
+
+Yesterday we mentioned the `when` function as an alternative to `if`.
+
+It might seem like a weaker form, so why would you use it?
+
+It turns out that `when` is is really useful for a few reasons.
+You might end up using it more than `if`!
+
+<!-- more -->
+
+
+## Argument Validation
+
+One particularly good place to use `when` is for argument validation.
+Typically when an argument is not valid, you'll want to throw an error.
+
+```yaml
+defn double-sqrt(x):
+  when not(number?(x)):
+    die: "x must be a number"
+  when x < 0:
+    die: "x must be positive"
+  =>: sqrt(x) * 2
+```
+
+An `if` would be inappropriate here, because when the condition is false,
+there's nothing to do.
+
+
+## when Returns nil
+
+Remember that YS is a functional language.
+Therefore the `when` function always has to return a value.
+
+If the condition is false, it returns `nil`.
+
+What if you need an `if` call that returns a number or a nil?
+
+You can just use `when` to do that.
+
+```yaml
+x =:
+  if a > b:
+    then: a + b
+    else: nil
+# Some thing as above:
+x =:
+  when a > b: a + b
+```
+
+
+## when Has do Semantics
+
+Remember how we used `then` and `else` in `if`, when we needed to do more than
+one thing?
+The `then` and `else` clauses compiled to a `do` form.
+
+Well `when` always lets you do that.
+
+```yaml
+when a < 0:
+  say: 'a'
+  say: 'is'
+  say: 'negative'
+```
+
+
+## when Has a Friend
+
+There's a function called `when-not` that is the opposite of `when`.
+
+Remember this from above?
+
+```yaml
+defn double-sqrt(x):
+  when not(number?(x)):
+    die: "x must be a number"
+```
+
+We could also write that as:
+
+```yaml
+defn double-sqrt(x):
+  when-not number?(x):
+    die: "x must be a number"
+```
+
+
+## `when` will I see you again?
+
+Probably tomorrow.

--- a/blog/2025-06-18.md
+++ b/blog/2025-06-18.md
@@ -1,0 +1,91 @@
+---
+title: Fancier YS Conditionals
+date: 2025-06-18
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-18.md
+comments: true
+---
+
+Most languages support a `case` or `switch` construct which is a way to handle
+multiple conditions.
+
+YS supports several similar but different constructs for this.
+
+Today we'll focus on the `cond` and `case` functions.
+
+<!-- more -->
+
+## Using `cond`
+
+The `cond` function takes an ordered set of pairs each consisting of a predicate
+and an action.
+Since we are writing code in YAML, it uses mappings for this.
+Each pair has a predicate key and an action value.
+
+```yaml
+# cond.ys
+!YS-v0
+each x [-1 2 30 400 5000 "sixty thousand"]:
+  kind =:
+    cond:
+      x:int?:not: "not a"
+      x < 0:      "a negative"
+      x < 10:     "a single digit"
+      x < 100:    "a double digit"
+      x < 1000:   "a triple digit"
+      else:       "a huge"
+  say: "$x is $kind number"
+```
+
+Let's run it:
+
+```bash
+$ ys cond.ys
+-1 is a negative number
+2 is a single digit number
+30 is a double digit number
+400 is a triple digit number
+5000 is a huge number
+sixty thousand is not a number
+```
+
+The `cond` function tries each predicate in order until one of them is true.
+Then it applies the action of that predicate and it is finished.
+
+
+## Just in `case`
+
+There's a similar function called `case`.
+This one takes a value and a set of things it might be equal to.
+The set consists of a mapping whose pairs contain a value and an action.
+The `case` function also supports an `else` pair, like `cond`.
+
+```
+# case.ys
+!YS-v0
+each n (1 .. 4):
+  say:
+    case n:
+      1: "One for the money."
+      2: "Two for the show."
+      3: "Three to get ready."
+      else: "Now, go cat, go!"
+```
+
+And then:
+
+```bash
+$ ys case.ys
+One for the money.
+Two for the show.
+Three to get ready.
+Now, go cat, go!
+```
+
+Your YS wish is my command.
+
+Gotta go!
+
+See you tomorrow.

--- a/blog/2025-06-19.md
+++ b/blog/2025-06-19.md
@@ -1,0 +1,112 @@
+---
+title: More Fancier YS Conditionals
+date: 2025-06-19
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-19.md
+comments: true
+---
+
+Yesterday we looked at the `cond` and `case` functions.
+
+The `cond` function has a couple cousins: `condp` and `condf`.
+
+Let's take a look at them.
+
+<!-- more -->
+
+
+## Using `condp`
+
+The `p` in `condp` stands for "predicate".
+A predicate is a function that returns a boolean value.
+
+The `condp` function takes a predicate function, a value and a set of pairs.
+
+The pairs consist of a value and an action.
+
+The predicate function should take two arguments and perform some sort of
+comparison.
+The first argument comes from the pair's value and the second argument is the
+initial value.
+
+Let's try it in yesterday's example.
+
+```
+# condp.ys
+!YS-v0
+each n (1 .. 4):
+  say:
+    condp eq n:
+      1: "One for the money."
+      2: "Two for the show."
+      3: "Three to get ready."
+      else: "Now, go cat, go!"
+```
+
+Here we use the `eq` function to compare the pair value to the topic value.
+Each pair is tried in order until one matches.
+The `else` pair is used if no match is found.
+
+It seems to work as expected when we run it.
+
+```bash
+$ ys condp.ys
+One for the money.
+Two for the show.
+Three to get ready.
+Now, go cat, go!
+```
+
+
+## Using `condf`
+
+The `f` in `condf` stands for "function".
+
+The `condf` function takes a value and a set of pairs.
+
+The pairs consist of a function and an action.
+
+The value is passed the the pair function which should return a boolean value.
+Each pair is tried in order until one matches.
+The `else` pair is used if no match is found.
+
+Let's try it out.
+
+```bash
+$ ys -e '
+each n [1 "two" 3.1415 true nil {}]:
+  say:
+    condf n:
+      nil?: "Value is nil."
+      true?: "Value is true."
+      int?: "$n is an integer."
+      float?: "$n is a float."
+      string?: "$n is a string."
+      else: "Value is something else."
+'
+1 is an integer.
+two is a string.
+3.1415 is a float.
+Value is true.
+Value is nil.
+Value is something else.
+```
+
+
+## Recap
+
+* `if` takes a condition, a then clause, and an else clause.
+* `when` takes a condition and a then block.
+* `cond` tries a set of cond/action pairs, tested in order.
+* `case` takes a value and tries a set of value/action pairs called in parallel.
+* `condp` takes a predicate function, a value, and a set of comparator/action
+  pairs, tested in order.
+* `condf` takes a value, and a set of function/action pairs.
+  The functions are called with the value and tested in order.
+
+
+YS has a lot of different ways to handle conditionals.
+
+Tomorrow we'll take a look at one more, the `when-let` function.

--- a/blog/2025-06-20.md
+++ b/blog/2025-06-20.md
@@ -1,0 +1,91 @@
+---
+title: whens and lets
+date: 2025-06-20
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-20.md
+comments: true
+---
+
+Do you know how a YS assignment actually works?
+
+It compiles into a Lisp `let` form.
+
+Let's take a look...
+
+<!-- more -->
+
+
+## Assignments are let bindings
+
+Here we compile a `main` function that assigns 2 variables, `x` and `y`.
+
+```bash
+$ ys -ce '
+defn main():
+  x =: 6
+  y =: 7
+  say: x * y
+'
+(defn main [] (let [x 6 y 7] (say (mul+ x y))))
+(apply main ARGS)
+```
+
+This makes it fairly easy to understand how variables inside functions are
+scoped.
+
+
+## `let` in `when`
+
+Let's try to use `let` and `when` together:
+
+```bash
+$ NAME=Cammie ys -e '
+defn main():
+  when ENV.NAME:
+    warn: "Hello, $(ENV.NAME)!"
+'
+Hello, Cammie!
+```
+
+This works, but we had to calculate `ENV.NAME` twice.
+We might not want to do that.
+
+We can solve it with a let binding.
+
+```bash
+$ NAME=Sammie ys -e '
+defn main():
+  name =: ENV.NAME
+  when name:
+    warn: "Hello, $name!"
+'
+Hello, Sammie!
+```
+
+This also works, but I don't like needing an assignment just to ask the
+question.
+
+
+## Introducing `when-let`
+
+There's a `when-let` function that does exactly what we want.
+
+```bash
+ NAME=Tammie ys -e '
+defn main():
+  when-let name ENV.NAME:
+    warn: "Hello, $name!"
+'
+Hello, Tammie!
+```
+
+Nice!
+
+There's also an `if-let` function, but it doesn't set the variable when the
+condition is not true.
+
+That's all I got for today.
+
+Let's get into some more interesting stuff this weekend!

--- a/blog/2025-06-21.md
+++ b/blog/2025-06-21.md
@@ -1,0 +1,221 @@
+---
+title: The `ys` Command
+date: 2025-06-21
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-21.md
+comments: true
+---
+
+There are different ways to use YS but the most common is to use it via the YS
+command-line tool: `ys`; a very versatile tool indeed.
+
+There's a lot you can do with `ys` including using it like you would use `jq` or
+`yq` one-liners:
+
+```bash
+$ jq .bar < <(echo '{"foo": 123, "bar": 456, "baz": 789}')
+456
+$ yq .bar < <(echo -e 'foo: 123\nbar: 456\nbaz: 789')
+456
+$ ys .bar < <(echo -e 'foo: 123\nbar: 456\nbaz: 789')
+456
+```
+
+Each of these tools have their own advantages and we'll be diving deep into
+those waters soon enough.
+
+Today let's just start by exploring the basic things you can do with the `ys`
+CLI.
+
+
+<!-- more -->
+
+!!! note "Installing ys"
+
+    `ys` is a standalone native binary executable for Mac and Linux (Windows
+    coming soon) that has releases [here](
+    https://github.com/yaml/yamlscript/releases).
+
+    Try `curl -sL getys.org/ys | bash` for a simple install, or...
+
+    Read the [ys installation instructions](https://yamlscript.org/doc/install/)
+    for the all the installation details.
+
+
+## The `ys` Basics
+
+Once you have `ys` installed, try:
+
+```bash
+$ ys
+
+ys - The YS Command Line Tool - v0.1.97
+
+Usage: ys [<option...>] [<file>]
+
+Options:
+
+  -e, --eval YSEXPR        Evaluate a YS expression
+                             multiple -e values are joined by newline
+  -l, --load               Output the (compact) JSON of YS evaluation
+  -f, --file FILE          Explicitly indicate input file
+
+  -c, --compile            Compile YS to Clojure
+  -b, --binary             Compile to a native binary executable
+
+  -p, --print              Print the final evaluation result value
+  -o, --output FILE        Output file for --load, --compile or --binary
+  -s, --stream             Output all results from a multi-document stream
+
+  -T, --to FORMAT          Output format for --load:
+                             json, yaml, csv, tsv, edn
+  -J, --json               Output (pretty) JSON for --load
+  -Y, --yaml               Output YAML for --load
+  -U, --unordered          Mappings don't preserve key order (faster)
+
+  -m, --mode MODE          Add a mode tag: code, data, or bare (for -e)
+  -C, --clojure            Treat input as Clojure code
+
+  -d                       Debug all compilation stages
+  -D, --debug-stage STAGE  Debug a specific compilation stage:
+                             parse, compose, resolve, build,
+                             transform, construct, print
+                           can be used multiple times
+  -S, --stack-trace        Print full stack trace for errors
+  -x, --xtrace             Print each expression before evaluation
+
+      --install            Install the libyamlscript shared library
+      --upgrade            Upgrade both ys and libyamlscript
+
+      --version            Print version and exit
+  -h, --help               Print this help and exit
+```
+
+Calling `ys` with no arguments is the same as `ys --help`.
+
+
+## Loading YAML with `ys`
+
+Let's start first with the `--load` option.
+
+It might sound strange to ask a CLI to "load" YAML.
+That's what a program does, right?
+It loads a YAML text into a native data structure inside the program.
+Where is a CLI going to load it into?
+
+When you tell `ys` to `--load` YAML, it will load it internally into a native
+data structure, but then it has to show you the result on stdout.
+
+The way it works is that `ys --load` will evaluate the YAML and then print the
+result as compact JSON!
+
+Why JSON?
+Patience!
+
+Let's start with this simple file:
+
+```yaml
+# sample.yaml
+name: Sammie
+age: 10
+favorite things:
+- ice cream
+- books
+- playing outside
+```
+
+Now let's load it with `ys`:
+
+```bash
+$ ys --load sample.yaml
+{"name":"Sammie","age":10,"favorite things":["cake","books","playing games"]}
+```
+
+You can also use `-l` (short for `--load`), -Y (short for `--yaml`), -J (short
+for `--json`) or `--to=<format>` for csv, tsv, edn and more.
+
+Since all JSON is valid YAML, you can also do anything with a JSON file that you
+can do with a YAML file.
+
+Let's pipe the above JSON output into `ys` again:
+
+```bash
+$ ys -l sample.yaml | ys -Y
+name: Sammie
+age: 10
+favorite things:
+- ice cream
+- books
+- playing outside
+```
+
+Looks like `ys` is a sweet little data file transformer!
+
+
+!!! note "The JSON Data Model"
+
+    Loading YAML to JSON is a very important concept about YS...
+
+    When you use it to load YAML, the result must be expressible as JSON.
+    YS thinks of JSON as the Lingua Franca of data models.
+
+
+## Let's get Dynamic!
+
+Sammie has more than 3 favorite things, and honestly they are changing all the
+time.
+
+Let's update the YAML file to include more favorite things:
+
+```yaml
+!YS-v0
+
+fun-things =::
+- ice cream
+- reading books
+- playing outside
+- jumping rope
+- building blocks
+- finger painting
+- bubble blowing
+- hide and seek
+- coloring books
+- toy cars
+- dress up clothes
+- board games
+- stuffed animals
+
+--- !data
+name: Sammie
+age: 10
+favorite things::
+  take 4:
+    shuffle(fun-things)
+```
+
+Here we've added a code mode document before the document we want to load to
+define a list of fun things.
+
+Let's see what happens when we load this file:
+
+```bash
+$ ys -Y sample.yaml
+name: Sammie
+age: 10
+favorite things:
+- finger painting
+- board games
+- hide and seek
+- dress up clothes
+```
+
+
+## Summer is Here!
+
+I feel like I could write a book about the `ys` CLI.
+
+Maybe I will!
+
+But today is the first day of Summer!

--- a/blog/2025-06-22.md
+++ b/blog/2025-06-22.md
@@ -1,0 +1,184 @@
+---
+title: The gist of YS
+date: 2025-06-22
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-22.md
+comments: true
+---
+
+Yesterday we started learning about the `ys` CLI and there's a lot more cool
+stuff to learn about it.
+
+But today I want to switch it up and talk about one of my favorite programs that
+I use many times a day.
+
+You probably know about [GitHub gists](https://gist.github.com).
+They are one of the best ways to share text files with others.
+
+Let's take a look!
+
+<!-- more -->
+
+
+## Making a Gist
+
+Yesterday we talked about a file called `sample.yaml`:
+
+```yaml
+!YS-v0
+
+fun-things =::
+- ice cream
+- reading books
+- playing outside
+- jumping rope
+- building blocks
+- finger painting
+- bubble blowing
+- hide and seek
+- coloring books
+- toy cars
+- dress up clothes
+- board games
+- stuffed animals
+
+--- !data
+name: Sammie
+age: 10
+favorite things::
+  take 4:
+    shuffle(fun-things)
+```
+
+Imagine you have this file on your computer and you want to share it with a
+friend on Slack.
+
+
+Just do this:
+
+```bash
+$ gist sample.yaml
+https://gist.github.com/ingydotnet/6a63ddce2bb2a7806f07a3408e0b7723
+```
+
+It's that easy!
+
+Now you can share [the URL](
+https://gist.github.com/ingydotnet/6a63ddce2bb2a7806f07a3408e0b7723) with your
+friend.
+
+
+## Gists of multiple files
+
+You can also create a gist of multiple files.
+
+Let's say we loaded that `sample.yaml` with `ys`:
+
+```bash
+$ ys -Y sample.yaml
+name: Sammie
+age: 10
+favorite things:
+- jumping rope
+- dress up clothes
+- stuffed animals
+- building blocks
+```
+
+and now we want to share the output as well:
+
+```bash
+$ ys -Y sample.yaml > output.yaml
+$ gist sample.yaml output.yaml
+https://gist.github.com/ingydotnet/18f6ece6ff4cfb54c439160bf9595560
+```
+
+There you go!
+
+[That gist](https://gist.github.com/ingydotnet/18f6ece6ff4cfb54c439160bf9595560)
+contains both the input and the output of the `ys` command.
+
+
+## gist is YS
+
+So we can see that gists are awesome and the `gist` command is super handy.
+But why am I writing about it for the Summer of YS??
+
+Well because it's a YS program!
+
+Let's take a look at the source code:
+
+```
+#!/usr/bin/env ys-0
+source <(curl '-sL' getys.org/run) "$@" :
+
+# Create a GitHub Gist from a list of files or from stdin
+
+api-token-file =: ENV.GIST_API_TOKEN_FILE |||
+  "$(ENV.HOME)/.gist-api-token"
+api-token =:
+  cond:
+    fs-f(api-token-file): api-token-file:read
+    ENV.GIST_API_TOKEN: ENV.GIST_API_TOKEN
+    else:
+      resp =:
+        sh:: |
+          bash -c '
+            echo -n "Enter your GitHub API Token: " >/dev/tty
+            read -r -s token </dev/tty
+            echo $token
+          '
+      say: ''
+      resp: .out
+api-token =: api-token:chomp
+
+api-url =: 'https://api.github.com/gists'
+
+re-stdin =: /^-(\.\w{1,8})?$/
+
+defn main(*files):
+  file-map =:
+    reduce _ {} (files || ['-']):
+      fn(map file):
+        m =: file =~ re-stdin
+        name =: m.if("stdin$(m.1)" file:fs/file-name)
+        content =: m.if('/dev/stdin' file):read
+        merge map: +
+          {name {:content content}}
+
+  request =::
+    :headers:: +{:Authorization "token $api-token"}
+    :body: !:json/dump
+      files:: file-map
+
+  response =: http/post(api-url request)
+
+  when-not 200 <= response.status <= 201:
+    die: "Gist request failed:\n\n$(response.body)"
+
+  say: json/load(response.body).html_url
+```
+
+I can't explain it all right now, but you can see that it makes an HTTP request
+to the GitHub API to create a gist.
+
+Give it a try!
+
+
+## Gisting gist
+
+Would you like a link to that source code?
+
+I have an idea...
+
+```bash
+$ gist `which gist`
+https://gist.github.com/ingydotnet/6126048571086156db4d145b5b5d802e
+```
+
+[Here's your gist](
+https://gist.github.com/ingydotnet/6126048571086156db4d145b5b5d802e)!
+
+That's it for today!

--- a/blog/2025-06-23.md
+++ b/blog/2025-06-23.md
@@ -1,0 +1,127 @@
+---
+title: YS One Liners
+date: 2025-06-23
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-23.md
+comments: true
+---
+
+There's almost nothing I like more about programming than one liners.
+
+A one liner is a single line of code that does something useful and doesn't
+require any extra steps to compile or run.
+
+You type one line, press enter, and get your result.
+
+I first learned about one liners in Perl.
+
+If we have a `file.txt` with the following content:
+
+```
+one
+two
+three
+four
+five
+```
+
+Here's a Perl one liner that counts the number of lines in a file:
+
+```bash
+$ perl -E '@l = <>; say scalar(@l)' < file.txt
+5
+```
+
+<!-- more -->
+
+
+## Collect them All!
+
+Let's do this in some other languages:
+
+* Python
+  ```bash
+  $ python -c 'import sys; print(len(sys.stdin.readlines()))' < file.txt
+  ```
+* Bash
+  ```bash
+  $ bash -c 'readarray _; echo ${#_[*]}' < file.txt 
+  5
+  ```
+* Ruby
+  ```bash
+  $ ruby -e 'puts ARGF.readlines.size' < file.txt
+  5
+  ```
+* JavaScript
+  ```bash
+  $ node -e 'console.log(require("fs").readFileSync(0).toString().split("\n").length-1)' < file.txt
+  5
+  ```
+
+I could go on all night but it's getting late.
+
+
+## YS One Liners
+
+Let's try this in YS:
+
+```bash
+$ ys -e 'say: IN:read:lines:count' < file.txt
+5
+```
+
+That's pretty nice.
+
+There's even a special shortcut for `:count`
+
+```bash
+$ ys -e 'say: IN:read:lines.#' < file.txt
+5
+```
+
+What happens if we don't `say` the result?
+
+```bash
+$ ys -e 'IN:read:lines.#' < file.txt
+```
+
+Nothing.
+Well, that makes sense.
+
+The `-e` flag is short for `--eval`.
+There's another flag `-p` that is short for `--print`.
+It prints the result of evaluating the expression.
+
+```bash
+$ ys -p -e 'IN:read:lines.#' < file.txt
+5
+```
+
+Like for most good CLIs, you can join the flags together:
+
+```bash
+$ ys -pe 'IN:read:lines.#' < file.txt
+5
+```
+
+## More to Come
+
+We'll be using YS one liners all Summer long.
+
+But like I said, it's getting late.
+
+Here's one for the road:
+
+```bash
+$ ys -e 'IN:read:lines.remove(/'\''/).remove(/[A-Z]/):shuffle.take(rand(5) + 3):joins:uc1.str("."):say' < /usr/share/dict/words
+Continuum butteriest segueing communing.
+```
+
+For when you want to take all the lowercase words without any apostrophes, then
+pick 3 - 8 of them at random, and join them all together into a sentence that
+starts with a capital letter and ends with a period.
+
+Good night!

--- a/blog/2025-06-24.md
+++ b/blog/2025-06-24.md
@@ -1,0 +1,128 @@
+---
+title: How Does YS Work?
+date: 2025-06-24
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-24.md
+comments: true
+---
+
+What if I told you that...
+
+* YS is made out of Java
+* YS uses no JVM
+* YS is a binary Executable
+* YS is also a Shared Library
+* YS is actually a Lisp
+* YS can use S-Expressions
+* YS prefers YeS-Expressions
+* YS can use modules written in:
+    * YS
+    * Any other language
+
+Make sense?
+
+<!-- more -->
+
+
+## YS is Clojure in Disguise
+
+If you haven't heard of Clojure, it's a Lisp that runs on the JVM.
+It has a wonderful core library, and loads of external libraries.
+In fact, it can use any Java library as well.
+
+When you run/load a YS YAML file, all the YAML is compiled to Clojure Lisp code.
+That code is then evaluated by a Clojure runtime called [SCI](
+https://github.com/babashka/sci/blob/master/API.md).
+
+If you were "loading" the file, then the last expression evaluated is serialized
+and returned (or printed if you're using `ys`).
+
+The best part of this is that you can use the entire Clojure core library and
+other key Clojure libraries in YS.
+
+
+## GraalVM
+
+Normally Java (and thus Clojure) needs to be run on the JVM.
+
+There is a project called [GraalVM](https://www.graalvm.org/) that can compile
+any jar files (JVM compiled code) to a native binary executable or shared
+library.
+
+YS uses this technology to compile to the `ys` binary executable and the
+`libyamlscript.so` shared library.
+The shared library is in turn bound to 11 (and counting) languages as a YS
+capable YAML loader module.
+
+
+## Using Java in YS
+
+For the most part you never need to use or even know about Java when using YS.
+You don't need to know about Clojure either; at least at first.
+As you get better at YS you'll end up learning more about Clojure (and it's a
+pretty cool language to know).
+You'll also learn more about Lisp!
+
+There are ways to call Java methods directly from YS, and there are certain
+times you might want to.
+Usually for performance reasons.
+I'll cover that in a future blog post.
+
+At this stage, the only place you'll see Java at all is from error stack traces.
+
+Let me show you an example:
+
+```bash
+$ ys -Se '1 / 0'
+Error: java.lang.ArithmeticException: Divide by zero
+ at clojure.lang.Numbers.divide (Numbers.java:190)
+    ys.std$div.invokeStatic (std.clj:270)
+    ys.std$div.invoke (std.clj:267)
+    clojure.lang.AFn.applyToHelper (AFn.java:156)
+    clojure.lang.RestFn.applyTo (RestFn.java:135)
+    clojure.core$apply.invokeStatic (core.clj:667)
+    ys.std$div_PLUS_.invokeStatic (std.clj:363)
+    ys.std$div_PLUS_.doInvoke (std.clj:363)
+    clojure.lang.RestFn.invoke (RestFn.java:424)
+    sci.lang.Var.invoke (lang.cljc:202)
+    sci.impl.analyzer$return_call$reify__5210.eval (analyzer.cljc:1422)
+    ...
+    sci.impl.interpreter$eval_string_STAR_.invokeStatic (interpreter.cljc:66)
+    sci.core$eval_string_PLUS_.invokeStatic (core.cljc:276)
+    yamlscript.runtime$eval_string.invokeStatic (runtime.clj:277)
+    yamlscript.cli$do_run.invokeStatic (cli.clj:373)
+    yamlscript.cli$do_main.invokeStatic (cli.clj:529)
+    yamlscript.cli$_main.invokeStatic (cli.clj:649)
+    yamlscript.cli$_main.doInvoke (cli.clj:643)
+    clojure.lang.RestFn.applyTo (RestFn.java:140)
+    yamlscript.cli.main (:-1)
+    java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit (LambdaForm$DMH:-1)
+```
+
+The `-S` flag is used to show the stack trace on an error.
+You can see `java.lang...` on the first and last lines.
+You also see a lot of Clojure and SCI in there.
+
+
+## The Secret is Out Now
+
+Whenever I give a talk about YS, or do a series on it, I try to hold off on
+mentioning Clojure or Java for a while.
+
+It's quite unlikely that you took interest in YS as an alternative way to code
+in those languages (although you certainly could).
+The main point of YS is to be a better way to work with YAML.
+
+But once I've let the cat out of the bag, it becomes much easier to explain
+what YS is and how it works.
+I'm looking forward to being able to explain things to you on a deeper level
+now.
+
+Before I go, I mentioned that YS can use modules written in any language.
+It's true!
+YS can use modules written in Java and Clojure of course.
+But they can also be written in Python or Ruby!
+
+Stay tuned!!!

--- a/blog/2025-06-25.md
+++ b/blog/2025-06-25.md
@@ -1,0 +1,408 @@
+---
+title: AI + Clojure Functions in YAML
+date: 2025-06-25
+draft: false
+authors: [ingydotnet]
+categories: [Summer-of-YS]
+edit: blog/2025-06-25.md
+comments: true
+---
+
+[Yesterday](2025-06-24.md) we learned that all YS YAML input compiles to Clojure
+(Lisp) before being evaluated by a native binary Clojure interpreter runtime.
+
+Does this mean that you could write Lisp functions in your YAML data files?
+And then call them on your data?
+
+Of course it does!
+
+<!-- more -->
+
+
+## Dynamic port numbers
+
+Let's imagine we have this `config.yaml` file:
+
+```yaml
+server:
+  host: localhost
+  port: 8080
+  ssl: true
+
+database:
+  driver: postgres
+  host: db.example.com
+  port: 5432
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+Now let's say we'd rather not need to specify the `port` values.
+We'd like the port to be automatically added depending on certain conditions.
+
+Here's a simplistic solution using a YS function:
+
+```yaml
+!YS-v0
+defn auto-port(mapping):
+  assoc mapping 'port': 1234
+
+--- !data
+server::
+  auto-port::
+    host: localhost
+    ssl: true
+
+database::
+  auto-port::
+    driver: postgres
+    host: db.example.com
+    name: myapp
+    credentials:
+      username: admin
+      password: s3cr3t
+```
+
+So we wrote a little YS function that takes a mapping and adds a `port` key with
+a value of `1234`.
+Not very exciting or useful, but it's a start.
+
+Next we put a function call to `auto-port` in front of the `server` and
+`database` mappings.
+This wasn't great because we had to indent those sections in order to call the
+function.
+
+Let's see if it works:
+
+```bash
+$ ys -Y config.yaml
+server:
+  host: localhost
+  ssl: true
+  port: 1234
+database:
+  driver: postgres
+  host: db.example.com
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+  port: 1234
+```
+
+Nice.
+It does work.
+It added the port to the end of each mapping, but that's OK (for now).
+
+Let's keep going on this one.
+
+
+## AI Generated YS
+
+Using a function to generate `1234` was silly.
+
+Let's say we want the `auto-port` function to return a random port number in the
+range of 8000-8999 if the `host` value is `localhost`.
+If the `driver` value is `postgres`, we'll use port 5432.
+Otherwise we'll return 0 (for unknown).
+
+Since we are new to YS and super busy, we'll use AI to generate the function.
+
+Here's the prompt:
+
+> Write a YS function that takes a mapping argument and returns the mapping with
+> a new pair added: `port: <number>`.
+> If the mapping has a `host` key and the value is `localhost`, use a random
+> port number in the range of 8000-8999.
+> If the mapping has a `driver` key and the value is `postgres`, use port 5432.
+> Otherwise use port 0 (for unknown).
+
+Here's the AI generated function:
+
+```yaml
+!YS-v0
+defn auto-port(mapping):
+  if mapping.get('host') == 'localhost':
+    return mapping.assoc('port' rand-int(8000, 8999))
+  elif mapping.get('driver') == 'postgres':
+    return mapping.assoc('port' 5432)
+```
+
+Let's see if it works:
+
+```bash
+$ ys -e "
+defn auto-port(mapping):
+  if mapping.get('host') == 'localhost':
+    return mapping.assoc('port' rand-int(8000, 8999))
+  elif mapping.get('driver') == 'postgres':
+    return mapping.assoc('port' 5432)
+
+autoport::
+  foo: 42"
+Error: Could not resolve symbol: return
+```
+
+Nope!
+Amazingly this generated code was actually valid YS syntax, because it compiled.
+Unfortunately this isn't how you write that in YS.
+
+!!! note
+
+    Use `ys -ce` in the command above to see the (broken) Clojure/Lisp code
+    that was generated.
+
+The overall problem is that YS is a new language and there isn't enough of it in
+the wild yet for AI to train on.
+
+
+## Using the `!clj` tag
+
+Clojure on the other hand is approaching 20 years old and has a lot of code out
+there.
+
+Let's see what we get with this prompt:
+
+> Write a Clojure function that takes a mapping argument and returns the mapping
+> with a new pair added: `port: <number>`.
+> If the mapping has a `host` key and the value is `localhost`, use a random
+> port number in the range of 8000-8999.
+> If the mapping has a `driver` key and the value is `postgres`, use port 5432.
+> Otherwise use port 0 (for unknown).
+
+
+Here's the function:
+
+```clojure
+(defn auto-port [mapping]
+  (if (= (get mapping "host") "localhost")
+    (assoc mapping "port" (+ 8000 (rand-int 1000)))
+    (if (= (get mapping "driver") "postgres")
+      (assoc mapping "port" 5432)
+      (assoc mapping "port" 0))))
+```
+
+The point of this post was to use Clojure functions in YAML.
+How do we do that?
+
+YS has a `!clj` tag that allows us to write raw Clojure code as strings in our
+YAML files.
+
+Let's put this all together in our `config.yaml` file:
+
+```yaml
+!YS-v0:
+
+=>: !clj |
+  (defn auto-port [mapping]
+    (if (= (get mapping "host") "localhost")
+      (assoc mapping "port" (+ 8000 (rand-int 1000)))
+      (if (= (get mapping "driver") "postgres")
+        (assoc mapping "port" 5432)
+        (assoc mapping "port" 0))))
+
+server: !:auto-port
+  host: localhost
+  port:
+  ssl: true
+
+database: !:auto-port
+  driver: postgres
+  host: db.example.com
+  port:
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+Before we try this out, let's look at what we did here.
+
+* We start in data mode with the `!YS-v0:` tag.
+* We use the `!clj` tag to define some code in raw Clojure.
+* Since we need a YAML pair here we use the dummy `=>` key.
+* We use a YAML `|` literal style scalar for the multi-line string.
+* We use the `!:<fn>` YS calling syntax to call the `auto-port` function.
+    * This saves us from indenting the mapping data.
+* We put an empty `port` pair to keep the desired position for the port pair.
+
+Now, let's load this:
+
+```bash
+$ ys -Y config.yaml
+server:
+  host: localhost
+  port: 8643
+  ssl: true
+database:
+  driver: postgres
+  host: db.example.com
+  port: 5432
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+Perfect!
+
+We were able to use AI to get something we wanted with minimal effort.
+
+
+## Back to the Future
+
+Assuming Clojure is the past and YS is the future... :joy:
+
+Let's go Back to the Future!
+
+Can we convert this Clojure code into YS?
+
+If you have the time in your busy day, then absolutely!
+
+Later on I'll show you a lot about how to go from Clojure back to YS, but for
+today I'll just do it for you:
+
+Here's a direct translation:
+
+```yaml
+!YS-v0
+
+defn auto-port(mapping):
+  if mapping.host == 'localhost':
+   assoc mapping "port": 8000 + rand-int(1000)
+   if mapping.driver == 'postgres':
+     assoc mapping 'port': 5432
+     assoc mapping 'port': 0
+
+--- !data
+server: !:auto-port
+  host: localhost
+  port:
+  ssl: true
+
+database: !:auto-port
+  driver: postgres
+  host: db.example.com
+  port:
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+and:
+
+```bash
+$ ys -Y config.yaml
+server:
+  host: localhost
+  port: 8151
+  ssl: true
+database:
+  driver: postgres
+  host: db.example.com
+  port: 5432
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+Voila!
+
+
+## Going all the way
+
+I know this post is already long, but the OCD in me wants to go all the way to
+how I'd probably do this for real.
+
+Let's move this helper function into a separate YS module file called
+`helpers.ys`.
+
+Also the AI didn't write the best idiomatic Clojure code.
+Let's tighten up the YS ported code a bit.
+
+Here's `config.yaml`:
+
+```yaml
+!YS-v0:
+:use helpers: :all
+
+server: !:auto-port
+  host: localhost
+  port:
+  ssl: true
+
+database: !:auto-port
+  driver: postgres
+  host: db.example.com
+  port:
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+and `helpers.ys`:
+
+```yaml
+!YS-v0
+ns: helpers
+
+defn auto-port(mapping):
+  assoc mapping 'port':
+    cond:
+      mapping.host == 'localhost':
+        8000 + rand-int(1000)
+      mapping.driver == 'postgres': 5432
+      else: 0
+```
+
+and:
+
+```bash
+$ ys -Y config.yaml
+server:
+  host: localhost
+  port: 8913
+  ssl: true
+database:
+  driver: postgres
+  host: db.example.com
+  port: 5432
+  name: myapp
+  credentials:
+    username: admin
+    password: s3cr3t
+```
+
+Excellent!
+
+
+## Conclusion
+
+That was probably the longest post of the [Summer of YS series](
+/blog/category/summer-of-ys/) so far.
+
+But like [I was telling you yesterday](2025-06-24.md#the-secret-is-out-now)...
+Now that you know that YS is Clojure in disguise, the sky is the limit for the
+cool stuff I can show you.
+
+----
+
+If you are enjoying these posts, the please add a "Reaction" below.
+
+And if you have comments or questions, just ask in the comment section there.
+I hope this post raised a lot of interesting possibilities in your mind.
+If that's the case, you must surely have questions!
+
+!!! note "Don't be shy!"
+
+    YS is a new language.
+    Don't be afraid to ask questions.
+    If you don't get something, then it's almost certain that others don't get
+    it either.
+
+    Just ask!!!

--- a/common/zild.mk
+++ b/common/zild.mk
@@ -14,6 +14,6 @@ ifneq (,$(shell command -v cpanm))
 endif
 
 ifneq (,$(shell command -v zild))
-$(ZILD_COMMANDS)::
+$(ZILD-COMMANDS)::
 	zild $@
 endif

--- a/doc/bindings.md
+++ b/doc/bindings.md
@@ -40,6 +40,7 @@ YS YAML loaders have major advantages over the existing YAML loaders:
 Currently there are working libraries for:
 
 * [Clojure](https://clojars.org/org.yamlscript/clj-yamlscript)
+* [Crystal](https://github.com/yaml/yamlscript-crystal)
 * [Go](https://github.com/yaml/yamlscript-go)
 * [Java](https://clojars.org/org.yamlscript/yamlscript)
 * [Julia](https://juliahub.com/ui/Packages/General/YAMLScript)

--- a/doc/control.md
+++ b/doc/control.md
@@ -98,7 +98,7 @@ Some expression contexts allow multiple expressions to be grouped together and
 some only allow a single expression.
 
 You can group multiple expressions together with a `do` function call when you
-need to to do multiple things in a context that only allows a single expression.
+need to do multiple things in a context that only allows a single expression.
 
 ```yaml
 if a > b:

--- a/doc/control.md
+++ b/doc/control.md
@@ -21,7 +21,7 @@ This document will cover:
 
 !!! note
 
-    Some of the things that are called "functions" in in this document are
+    Some of the things that are called "functions" in this document are
     actually "macros" or "special forms" in Clojure.
     The distinction is not particularly important here, but worth mentioning.
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -42,7 +42,7 @@ This page contains a links to programs written in YS.
   * [util/release-yamlscript](
     https://github.com/yaml/yamlscript/blob/main/util/release-yamlscript)
     The utility that orchestrates the release of YS, including 12 binary builds
-    and `libyamlscript.so` bindings for 10 programming languages.
+    and `libyamlscript.so` bindings for 11 programming languages.
   * [util/brew-update](
     https://github.com/yaml/yamlscript/blob/main/util/brew-update)
     The utility that updates the Homebrew formula for YS.

--- a/doc/install.md
+++ b/doc/install.md
@@ -98,6 +98,7 @@ YS loader libraries are currently available for these programming
 languages:
 
 * [Clojure](https://clojars.org/org.yamlscript/clj-yamlscript)
+* [Crystal](https://github.com/yaml/yamlscript-crystal)
 * [Go](https://github.com/yaml/yamlscript-go)
 * [Java](https://clojars.org/org.yamlscript/yamlscript)
 * [Julia](https://juliahub.com/ui/Packages/General/YAMLScript)

--- a/doc/install.md
+++ b/doc/install.md
@@ -12,7 +12,21 @@ YS has 3 main things you might want to install:
    particular programming language, like Python, Rust, NodeJS, etc.
 
 
-### Quick Install of `ys` and `libyamlscript`
+## Install `ys` with Homebrew
+
+You can install `ys` on macOS or Linux with Homebrew.
+
+Just run these commands:
+
+```bash
+brew tap yaml/yamlscript
+brew install ys
+```
+
+Homebrew support for installing `libyamlscript` is coming soon.
+
+
+### Quick Install Script for `ys` and `libyamlscript`
 
 You can install both `ys` and `libyamlscript` with a single CLI command, where:
 
@@ -33,7 +47,7 @@ For the `ys` command you'll need to have `PREFIX/bin` in your `PATH`, but the
 install script will tell you that.
 
 For `libyamlscript`, unless you use the default `PREFIX` you'll need to add
-`PREFIX/lib` to `LD_LIBRARY_PATH` and export that variable.
+`PREFIX/lib` to your `LD_LIBRARY_PATH`.
 
 !!! note "An even shorter command to install `ys`"
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -9,7 +9,7 @@ YS embeds cleanly into existing YAML files and adds new capabilities such as:
 
 * Getting data from other YAML files
 * Assigning variables
-* Referencing other parts of YAML (without anchorsi/aliases)
+* Referencing other parts of YAML (without anchors/aliases)
 * Interpolating variables and function calls into strings
 * Transforming data structures
 * Defining and calling functions

--- a/doc/loaders.md
+++ b/doc/loaders.md
@@ -17,6 +17,7 @@ language.
 The following loader libraries are currently available:
 
 * [Clojure](https://clojars.org/org.yamlscript/clj-yamlscript)
+* [Crystal](https://github.com/yaml/yamlscript-crystal)
 * [Go](https://github.com/yaml/yamlscript-go)
 * [Java](https://clojars.org/org.yamlscript/yamlscript)
 * [Julia](https://juliahub.com/ui/Packages/General/YAMLScript)

--- a/doc/query.md
+++ b/doc/query.md
@@ -53,6 +53,7 @@ Click on the examples below to see more details.
 
     ??? "`ys -J file.yaml   # Convert to JSON`"
         Use one of these Load options:
+
         * `-l`/`--load` Load input and print as compact JSON
         * `-J`/`--json` Print as formatted JSON
         * `-Y`/`--yaml` Print as YAML

--- a/doc/v1-planning.md
+++ b/doc/v1-planning.md
@@ -1,0 +1,168 @@
+---
+title: YS v1 Planning
+comments: true
+---
+
+
+See [YS Versioning](ys-versioning.md) for a description of YS language
+versioning.
+
+This document describes the changes that we need to make in order to release YS
+v0 as stable, then release YS v1 as stable, and then start working on YS v2.
+
+
+## Basic Rules for v1
+
+* Every YS enabled YAML file (stream) must start with a YS stream tag like
+  `!YS/v1`.
+* That will declare the semantics for the entire stream.
+* A stream can import other streams of different versions.
+* A runtime of v3 should support v1, v2 and v3, but not v4 or higher.
+* The `v0` version usage will be deprecated soon after v1 is released.
+
+
+## YS Stream Tags
+
+Currently we allow these tags to start a YAML stream:
+
+- `!yamlscript/v0`
+- `!yamlscript/v0:`
+- `!yamlscript/v0/bare`
+- `!yamlscript/v0/code`
+- `!yamlscript/v0/data`
+- `!YS-v0`
+- `!YS-v0:`
+
+Tags ending with `:` imply data mode.
+This is meant to be analogous to the `::` syntax we use for mode switching.
+
+These tags can currently start any document.
+
+After a document is started with one of these tags, subsequent documents can
+start with a `!code`, `!data`, or (the default) `!bare` tag.
+
+
+### v1 Planned Changes
+
+We will allow these `!YS-v#` tags to start a YAML stream (they will be only
+allowed on the first document in the stream):
+
+* `!yamlscript.org/v1`  # Long form
+* `!YS/v1`              # Short form
+* `!YS-v0`              # Legacy v0 form
+
+Note: each of those imply code mode and can have a `:` suffix to imply data
+mode.
+
+To start in bare mode you can use:
+
+```yaml
+!YS/v1
+---
+foo: bar
+```
+
+or:
+
+```yaml
+!YS/v1
+--- !bare
+foo: bar
+```
+
+In the first case, we are starting in code mode, but since we immediately
+introduce a new document and that document has no tag, it will be in bare mode.
+
+In the second case we do the same thing, but we explicitly state that we want
+bare mode.
+
+Both of these examples technically have two documents, but the initial document
+will do nothing since it evaluates to `nil` (even in `-s` streaming mode because
+`nil` values are not added to the stream).
+
+The implicit mode (no tag) is always bare mode.
+
+For data mode, we can use:
+
+```yaml
+!YS/v1:
+foo: bar
+```
+
+or:
+
+```yaml
+!YS/v1
+--- !data
+foo: bar
+```
+
+
+### URL Tags
+
+`!YS/v1` is short for `!yamlscript.org/v1` and that will be a URL that can do
+interesting things:
+
+* `docs.yamlscript.org/v1` might be the docs.
+* `spec.yamlscript.org/v1` might be the spec.
+* `schema.yamlscript.org/v1` might be the schema.
+
+
+## YS Namespaces
+
+Right now yamlscript using `yamlscript.*` and `ys.*` namespaces internally.
+It exposes a number of the `ys.*` namespaces to the user.
+
+In v1 and v2 these namespaces will have differing behavior.
+
+Each YS stream (file) will be tied to a particular major version.
+
+We need to rename the internal namespaces to something like `ys.v0.*` and
+`yamlscript.v0.*`.
+Then introduce `ys.v1.*` and `yamlscript.v1.*` for the next major version.
+
+The new namespaces can "inherit" from the old namespaces and change the things
+they need to.
+
+
+## Documentation
+
+Each version will have its own documentation.
+
+The web site will need to have a version selector.
+
+We need a URL format for the different versions of the documentation.
+
+
+## v0 Review and Cleanup
+
+We should try to get v0 to a place where it is tight and stable.
+
+This might mean getting rid of some of the features that didn't work out.
+
+
+### Binary Size
+
+We should try to reduce the size of the binary a bit.
+
+
+### Bundled Libraries
+
+We should remove the bundled libraries that are not heavily used and could
+easily be added as dependencies by programs.
+
+
+### Remove `std/fs-*` functions
+
+Since functions like `fs-e` are also available as `fs/e` we should remove the
+aliases and just keep the `fs` namespace.
+
+
+### Finish `use` and `dep`
+
+We need to finish `use` and `dep` commands before v1 is stable.
+
+
+### Binding Capabilities
+
+We should switch the binding capabilities to not allow code mode by default.

--- a/doc/ys-versioning.md
+++ b/doc/ys-versioning.md
@@ -1,0 +1,135 @@
+---
+title: YS Versioning
+comments: true
+---
+
+
+YS is a "versioned" programming language.
+
+It uses the [Semantic Versioning](https://semver.org/) scheme.
+
+Major compatibility breaking changes are allowed between major versions.
+
+All programs and data files that use YS code expressions must declare the major
+version of YS they use.
+
+The current major version is `0` and that means that the language is still
+under development.
+That said, the language has been fairly stable for a while now.
+
+Very soon we will declare v0 stable and start working on v1.
+Soon after that v1 will be declared stable and we'll start working on v2.
+The v1 "development" period is just a practice run for switching major versions.
+v1 stable should be nearly identical to v0 stable.
+
+In fact, we plan to deprecate v0 after v1 is stable.
+After a couple months of v0 deprecation, use of v0 will be disallowed.
+
+The v2 "development" period will be a much longer period.
+
+The stable v2 runtime will support both v1 and v2 programs and libraries.
+
+See [YS v1 Planning](v1-planning.md) for a description of the changes we need to
+make to release YS v0 as a stable YS v1, and then start working on YS v2.
+
+
+## Rules for version usage
+
+YS programs must declare their major version.
+
+They usually do this with a stream tag like `!YS/v1`.
+
+They can also use a shebang line to declare the version.
+
+```yaml
+#!/usr/bin/env ys-1
+```
+
+You need the `-1` part or `!YS/v1` won't be added.
+You could, of course, do this:
+
+```yaml
+#!/usr/bin/env ys
+!YS/v1
+```
+
+!!! note "-e versioning"
+
+    When using the `-e` flag, the expression is assumed to be code mode and an
+    explicit `!YS/v1` tag is not needed.
+    This is for simplicity of 1-liners.
+
+    The version is determined by the major version of the `ys` binary being
+    used.
+
+
+## Rules for new version development
+
+Work on v2 might last a year.
+During that time, we will be putting out new v1 releases.
+
+We will also be putting out new v2 alpha releases on a regular basis.
+
+We want to let people start using v2 as soon as possible.
+
+This requires that we have a v2 versioning scheme in place, and that we have
+syntax rules to use v2.
+
+These rules should be compatible with semver rules.
+
+
+### Current v0 binary naming
+
+* `<prefix>/bin/ys` (symlink)
+* `<prefix>/bin/ys-0` (symlink)
+* `<prefix>/bin/ys-0.1.97`
+* `<prefix>/lib/libyamlscript.so-0.1.97`
+
+
+### New v1 naming
+
+* `<prefix>/bin/ys` (symlink)
+* `<prefix>/bin/ys1` (symlink)
+* `<prefix>/bin/ys-1` (symlink)
+* `<prefix>/bin/ys-1.2.3`
+* `<prefix>/lib/libyamlscript.so-1`
+
+When v1 is final stable, we just need to match the major version.
+
+
+### New v2 naming
+
+For the time where v1 is final stable and v2 is in development.
+
+During development the version will always start with `2.0.0`.
+Then we'll have a `-alpha` suffix followed by a minor and patch version.
+
+When alpha-minor is zero then any change can happen.
+This is like a normal major version of `0`.
+
+So we start at `2.0.0-alpha.0.1`.
+This is kinda like a `2.0.1` version that is alpha (mentally removing the
+`.0.0-alpha.` part).
+When we go to `2.0.0-alpha.1.1` we've made come to a point where things are
+stabilizing and we want to indicate a breaking change by bumping the alpha-minor
+number.
+
+This scheme is compatible with semver and ever increasing versions.
+
+
+### New v2 binary naming
+
+* `<prefix>/bin/ys` (symlink)
+* `<prefix>/bin/ys2` (symlink)
+* `<prefix>/bin/ys-2a` (symlink)
+* `<prefix>/bin/ys-2.0.0-alpha.0.1`
+* `<prefix>/lib/libyamlscript.so-2.0.0-alpha.0.1`
+
+
+### v2 shebangs
+
+To use a shebang for v2 while it is still in development, we can:
+
+```yaml
+#!/usr/bin/env ys-2a
+```

--- a/www/Makefile
+++ b/www/Makefile
@@ -7,6 +7,8 @@ CONFIG := mkdocs.yml
 
 PYTHON-VENV := $(ROOT)/www/.venv
 VENV := source $(PYTHON-VENV)/bin/activate
+export VIRTUAL_ENV := $(PYTHON-VENV)
+export PATH := $(PYTHON-VENV)/bin:$(PATH)
 
 MD-FILES := $(shell find ../doc -name '*.md' | sort)
 MDYS-FILES := $(shell find ../doc src -name '*.mdys' | sort)
@@ -17,7 +19,7 @@ MD-FILES := $(MD-FILES:%.mdys=%.md)
 BLOG-FILES := $(shell find ../blog -name '*.md' | sort)
 BLOG-FILES := $(BLOG-FILES:../blog/%=src/blog/posts/%)
 
-WATCHER := $(VENV) && watchmedo shell-command
+WATCHER := watchmedo shell-command
 WATCH := \
   Meta \
   doc/ \
@@ -44,7 +46,7 @@ DIRS := \
 
 DEPS := \
   build-bin-ys \
-	$(DIRS) \
+  $(DIRS) \
   $(PYTHON-VENV) \
   $(CONFIG) \
   $(MD-FILES) \
@@ -74,10 +76,11 @@ build site:: $(DIRS) $(DEPS)
 	$(RM) -r site/*
 	$(VENV) && mkdocs build
 	echo $(YS-WWW-DOMAIN) > site/CNAME
+	mkdocs build
 	git -C site add -A
 
 serve: $(DIRS) $(DEPS) watch
-	$(VENV) && mkdocs serve
+	mkdocs serve
 
 deps-update: deps-update-notify deps
 
@@ -122,7 +125,7 @@ watch:
 	  &
 
 material: $(PYTHON-VENV)
-	ln -s $(PYTHON-VENV)/lib/python*/site-packages/material $@
+	ln -s $</lib/python*/site-packages/material $@
 
 override: material
 ifeq (,$(f))
@@ -140,8 +143,8 @@ ifeq (,$(m))
 	@echo 'm=<module> is not set'
 	@exit 1
 endif
-	$(VENV) && pip install $m
-	$(VENV) && pip freeze > requirements.txt
+	pip install $m
+	pip freeze > requirements.txt
 
 clean::
 	killall watchmedo || true
@@ -154,7 +157,7 @@ realclean:: clean
 
 $(PYTHON-VENV):
 	$(PYTHON) -m venv $@
-	$(VENV) && pip install -r requirements.txt
+	pip install -r requirements.txt
 
 # YS doesn't support !!python tags yet.
 # This hack is a workaround to preserve them.
@@ -201,6 +204,3 @@ sample:
 
 line1 line2:
 	@echo =======================================================================
-
-# yamlscript-1920x1080.png: src/image/yamlscript.svg
-# 	svgexport $< $@ 1920:1080 pad

--- a/www/Makefile
+++ b/www/Makefile
@@ -107,6 +107,9 @@ endif
 watchmedo-help:
 	$(WATCHER) --help | less
 
+# NOTE: Dont use '--wait' here. '--drop' prevents running too much.
+#
+# https://github.com/gorakhargosh/watchdog/issues/136#issuecomment-40088653
 watch:
 	: Starting watching: '$(WATCH)'
 	@cd .. && \
@@ -120,7 +123,6 @@ watch:
 	  --patterns='$(WATCH)' \
 	  --recursive \
 	  --timeout=2 \
-	  --wait \
 	  --drop \
 	  &
 

--- a/www/Makefile
+++ b/www/Makefile
@@ -58,9 +58,9 @@ default::
 
 deps: line1 $(DEPS) line2
 
+YS-WWW-DOMAIN := yamlscript.org
 ifeq (live,$(website))
   export YS_WWW_LIVE := true
-  YS-WWW-DOMAIN := yamlscript.org
   YS-WWW-REMOTE := origin
   YS-WWW-BRANCH ?= gh-pages
 else ifeq (stage,$(website))
@@ -76,7 +76,6 @@ build site:: $(DIRS) $(DEPS)
 	$(RM) -r site/*
 	$(VENV) && mkdocs build
 	echo $(YS-WWW-DOMAIN) > site/CNAME
-	mkdocs build
 	git -C site add -A
 
 serve: $(DIRS) $(DEPS) watch

--- a/www/config/use.yaml
+++ b/www/config/use.yaml
@@ -13,11 +13,11 @@
 # - Static Site Generators:
 #   - This site
 
-- Hacks:
-  - hacks.md
-  - gist.md
-  - yamllm.md
-# - sbs.md
+# - Hacks:
+#   - hacks.md
+#   - gist.md
+#   - yamllm.md
+#   - sbs.md
 
 # - hacks/index.md:
 #   - yamllm.md

--- a/www/mkdocs.ys
+++ b/www/mkdocs.ys
@@ -91,6 +91,7 @@ plugins:
     categories_allowed:
     - General
     - Advent-2023
+    - Summer-of-YS
     post_date_format: long
     post_dir: blog/posts
     post_url_date_format: yyyy-MM-dd

--- a/www/src/contrib-website.md
+++ b/www/src/contrib-website.md
@@ -59,7 +59,7 @@ The `make serve` command will install all the dependencies in the `./.venv/` and
 in `/tmp/yamlscript/` and then start a local webserver at
 <http://localhost:8000>.
 
-It will aslo start a watcher that will automatically rebuild the site when you
+It will also start a watcher that will automatically rebuild the site when you
 make changes to the source files.
 These  changes will be visible in your browser immediately.
 

--- a/www/src/hacks.md
+++ b/www/src/hacks.md
@@ -3,8 +3,9 @@ title: YS Hacks
 talk: 0
 ---
 
-
+<!--
 Here are some interesting real-world hacks that have been done with YS.
 
 * [GitHub Gist](gist.md) — Post GitHub Gists from the command line.
 * [YAMLLM](yamllm.md) — a command line tool to query common LLM APIs.
+-->

--- a/www/src/index.mdys
+++ b/www/src/index.mdys
@@ -94,8 +94,9 @@ Learn More About YS</a></div>
     curl -s https://getys.org/ys | bash
     # Adjust PATH if asked to.
     ys --help
-    ys -e 'say: "Hello, World!"'
+    ys -e 'say: "Hello, World. I am $(ENV.USER)."'
     ```
+    [:octicons-arrow-right-24: Installing YS](doc/install.md)
 ```
 
 ```mdys:YS-CODE

--- a/www/src/install
+++ b/www/src/install
@@ -16,12 +16,12 @@ export VERSION
 main() (
   setup "$@"
 
-  if ! [[ ${BIN-} || ${LIB-} ]]; then
-    install ys
-    install libyamlscript
-  elif [[ ${BIN-} ]]; then
+  if [[ ${BIN-} ]]; then
     install ys
   elif [[ ${LIB-} ]]; then
+    install libyamlscript
+  else
+    install ys
     install libyamlscript
   fi
 )
@@ -43,22 +43,24 @@ install() (
     make -s --no-print-directory -C "$name"-* install
   )
 
-  if [[ $name == ys &&
+  if [[ ! ${QUIET-} &&
+        $name == ys &&
         $PATH != *"$PREFIX"/bin*
      ]]; then
-    echo
-    echo "  *** WARNING: '$PREFIX/bin' is not in your PATH yet ***"
-    echo
-    echo "  You can add it by running:"
-    echo "    export PATH=$PREFIX/bin:\$PATH"
-    echo
-    echo "  Make it permanent by adding the above line to your shell profile."
-    echo
-    echo "  For full details: https://yamlscript.org/doc/install"
-    echo
+    echo "
+  *** WARNING: '$PREFIX/bin' is not in your PATH yet ***
+
+  You can add it by running:
+    export PATH=$PREFIX/bin:\$PATH
+
+  Make it permanent by adding the above line to your shell profile.
+
+  For full details: https://yamlscript.org/doc/install
+"
   fi
 
-  if [[ $name == libyamlscript &&
+  if [[ ! ${QUIET-} &&
+        $name == libyamlscript &&
         $PREFIX != "$HOME/.local" &&
         $PREFIX != /usr/local &&
         ${LD_LIBRARY_PATH-} != *"$PREFIX"/lib*
@@ -70,7 +72,8 @@ install() (
 )
 
 setup() {
-  vers=$VERSION
+
+  vers=${VERSION:-$DEFAULT_VERSION}
 
   if [[ ! ${PREFIX-} ]]; then
     if [[ $(id -u) == 0 ]]; then
@@ -86,7 +89,7 @@ setup() {
   elif [[ $OSTYPE == *linux* ]]; then
     os=linux
   else
-    die "Unknown OS type: $OSTYPE"
+    die "Unknown/unsupported OS type: '$OSTYPE'"
   fi
 
   if [[ $MACHTYPE == *x86_64* ]]; then
@@ -94,7 +97,7 @@ setup() {
   elif [[ $MACHTYPE == *arm64* || $MACHTYPE == *aarch64* ]]; then
     arch=aarch64
   else
-    die "Unknown machine type: $MACHTYPE"
+    die "Unknown machine/unsupported type: '$MACHTYPE'"
   fi
 
   url=https://github.com/yaml/yamlscript/releases/download/

--- a/www/src/press.md
+++ b/www/src/press.md
@@ -33,8 +33,7 @@ hide:
 * [Seajure March 2024 - YAMLScript](
   https://www.youtube.com/watch?v=GajOBwBcFyA)
 
-<!--
 ## Meetups
 
+* [Toronto Enterprise DevOps 2025-06-12](https://github.com/yaml/yamlscript/tree/talk/devops-416/)
 * [Toronto Smarter DevOps 2025-02-13](https://yamlscript.org/talk/20250213/)
--->

--- a/www/src/rejekts.md
+++ b/www/src/rejekts.md
@@ -1,0 +1,7 @@
+---
+title: Kubernetes Rejekts 2025 London
+talk: 0
+---
+
+* [YS Lightning Talk Slides](https://github.com/yaml/yamlscript/blob/talk/rejekts/slides.vroom)
+* [Contact Ingy](ingydotnet.md)

--- a/www/theme/partials/comments.html
+++ b/www/theme/partials/comments.html
@@ -1,0 +1,55 @@
+{% if page.meta.comments %}
+  <h2 id="__comments">{{ lang.t("meta.comments") }}</h2>
+  <!-- Insert generated snippet here -->
+  <script src="https://giscus.app/client.js"
+    data-repo="yaml/yamlscript"
+    data-repo-id="R_kgDOHmgdIg"
+    data-category="Blog Post Discussions"
+    data-category-id="DIC_kwDOHmgdIs4Cq6mr"
+    data-mapping="pathname"
+    data-strict="0"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="bottom"
+    data-theme="preferred_color_scheme"
+    data-lang="en"
+    crossorigin="anonymous"
+    async>
+  </script>
+
+  <!-- Synchronize Giscus theme with palette -->
+  <script>
+    var giscus = document.querySelector("script[src*=giscus]")
+
+    // Set palette on initial load
+    var palette = __md_get("__palette")
+    if (palette && typeof palette.color === "object") {
+      var theme = palette.color.scheme === "slate"
+        ? "transparent_dark"
+        : "light"
+
+      // Instruct Giscus to set theme
+      giscus.setAttribute("data-theme", theme) 
+    }
+
+    // Register event handlers after documented loaded
+    document.addEventListener("DOMContentLoaded", function() {
+      var ref = document.querySelector("[data-md-component=palette]")
+      ref.addEventListener("change", function() {
+        var palette = __md_get("__palette")
+        if (palette && typeof palette.color === "object") {
+          var theme = palette.color.scheme === "slate"
+            ? "transparent_dark"
+            : "light"
+
+          // Instruct Giscus to change theme
+          var frame = document.querySelector(".giscus-frame")
+          frame.contentWindow.postMessage(
+            { giscus: { setConfig: { theme } } },
+            "https://giscus.app"
+          )
+        }
+      })
+    })
+  </script>
+{% endif %}


### PR DESCRIPTION
A few typo fixes from the `doc/` and `blog/` pages.