### PR TITLE
crystal: fix library path for reproducible test builds

### DIFF
--- a/crystal/Makefile
+++ b/crystal/Makefile
@@ -11,6 +11,9 @@ BASE := $(ROOT)/crystal
 LIBYS-SO-PATH := $(ROOT)/libys/lib/$(LIBYS-SO-FQNP)
 BUILD-DEPS := $(LIBYS-SO-PATH)
 
+# Set library path for Crystal compiler
+CRYSTAL_ENV := LIBRARY_PATH=$(ROOT)/libys/lib LD_LIBRARY_PATH=$(ROOT)/libys/lib
+
 #------------------------------------------------------------------------------
 
 build:: build-doc
@@ -22,13 +25,13 @@ test:: test-example test-crystal test-ffi
 endif
 
 test-example: $(BUILD-DEPS)
-	$(CRYSTAL) run examples/simple.cr
+	$(CRYSTAL_ENV) $(CRYSTAL) run examples/simple.cr
 
 test-crystal: $(BUILD-DEPS)
-	$(CRYSTAL) spec
+	$(CRYSTAL_ENV) $(CRYSTAL) spec
 
 test-ffi: $(BUILD-DEPS)
-	$(CRYSTAL) run test/ffi.cr
+	$(CRYSTAL_ENV) $(CRYSTAL) run test/ffi.cr
 
 release:
 	$(ROOT)/util/release-crystal


### PR DESCRIPTION
add CRYSTAL_ENV variable to set LIBRARY_PATH and LD_LIBRARY_PATH for all crystal test commands. this ensures the libys shared library is found during both compile-time linking and runtime execution.

fixes linking errors where crystal compiler couldn't find -lys library.